### PR TITLE
fix: used value-based comparison in DeserializeCustomMap to ensure correct parameter mapping in parallel execution

### DIFF
--- a/src/Chrysalis/Cbor/CborSerializer.cs
+++ b/src/Chrysalis/Cbor/CborSerializer.cs
@@ -905,7 +905,14 @@ public static class CborSerializer
 
                 if (parameterMap.TryGetValue(key.ToString()!, out var paramInfo))
                 {
-                    int index = Array.IndexOf(targetType.GetConstructors().First().GetParameters(), paramInfo.Parameter);
+                    ParameterInfo[] firstParams = targetType.GetConstructors().First().GetParameters();
+                    ParameterInfo secondParams = paramInfo.Parameter;
+
+                    int index = firstParams.ToList().FindIndex(p =>
+                        p.Name == secondParams.Name &&
+                        p.ParameterType == secondParams.ParameterType
+                    );
+
                     values[index] = DeserializeCbor(reader, paramInfo.Parameter.ParameterType);
                 }
                 else


### PR DESCRIPTION
This pull request shows the replacement of `Array.IndexOf` with a value-based `FindIndex` in `DeserializeCustomMap`. This change addresses an issue where `Array.IndexOf` was performing reference equality comparisons on `ParameterInfo` objects, which failed in parallel execution due to different instances representing the same parameters. By comparing parameter names and types, we ensure correct parameter mapping regardless of whether deserialization is performed sequentially or in parallel.