### PR TITLE
chore: bump version to 0.4.1

### DIFF
--- a/src/Chrysalis/Chrysalis.csproj
+++ b/src/Chrysalis/Chrysalis.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>0.4.0</Version>
+    <Version>0.4.1</Version>
     <PackageId>Chrysalis</PackageId>
     <Authors>clark@saib.dev</Authors>
     <Company>SAIB Inc</Company>


### PR DESCRIPTION
This pull request bumps the Chrysalis version to 0.4.1.