### PR TITLE
refactor: add NullableConverter and CborNullable type with associated test data

### DIFF
--- a/src/Chrysalis.Test/Types/Primitives/NullableTestData.cs
+++ b/src/Chrysalis.Test/Types/Primitives/NullableTestData.cs
@@ -1,0 +1,35 @@
+using Chrysalis.Cbor.Types;
+using Chrysalis.Cbor.Types.Primitives;
+
+namespace Chrysalis.Test.Types.Primitives;
+
+public record InheritedNullable<T>(T? Value) : CborNullable<T>(Value) where T : CborBase;
+public record NestedInheritedNullable<T>(T? Value) : InheritedNullable<T>(Value) where T : CborBase;
+
+public class NullableTestData
+{
+    public readonly static string _testTag = "CborNullable";
+
+    public static IEnumerable<TestData> TestData
+    {
+        get
+        {
+            // Test with int
+            yield return new("Basic Null Int", "f6", new CborNullable<CborInt>(null));
+            yield return new("Basic Value Int", "01", new CborNullable<CborInt>(new CborInt(1)));
+            yield return new("Inherited Null Int", "f6", new InheritedNullable<CborInt>(null));
+            yield return new("Inherited Value Int", "01", new InheritedNullable<CborInt>(new CborInt(1)));
+            yield return new("Nested Inherited Null Int", "f6", new NestedInheritedNullable<CborInt>(null));
+            yield return new("Nested Inherited Value Int", "01", new NestedInheritedNullable<CborInt>(new CborInt(1)));
+        }
+    }
+
+    public static IEnumerable<object[]> GetTestData()
+    {
+        return TestData.Select(testData =>
+        {
+            testData.Description = $"[{_testTag}] {testData.Description}";
+            return new object[] { testData };
+        });
+    }
+}

--- a/src/Chrysalis/Cbor/Converters/Primitives/NullableConverter.cs
+++ b/src/Chrysalis/Cbor/Converters/Primitives/NullableConverter.cs
@@ -1,0 +1,57 @@
+using System.Formats.Cbor;
+using Chrysalis.Cbor.Types;
+using System.Reflection;
+
+namespace Chrysalis.Cbor.Converters.Primitives;
+
+public class NullableConverter : ICborConverter
+{
+    public T Deserialize<T>(byte[] data) where T : CborBase
+    {
+        CborReader reader = new(data);
+        Type targetType = typeof(T);
+        Type valueType = targetType.GetGenericArguments()[0];
+
+        ConstructorInfo constructor = targetType.GetConstructor([valueType])
+            ?? throw new InvalidOperationException($"Type {targetType.Name} does not have a suitable constructor.");
+
+        object? value;
+        if (reader.PeekState() == CborReaderState.Null)
+        {
+            reader.ReadNull();
+            value = null;
+        }
+        else
+        {
+            value = typeof(CborSerializer)
+                .GetMethod(nameof(CborSerializer.Deserialize))!
+                .MakeGenericMethod(valueType)
+                .Invoke(null, [data]);
+        }
+
+        CborBase instance = (T)constructor.Invoke([value]);
+        instance.Raw = data;
+        return (T)constructor.Invoke([value]);
+    }
+
+    public byte[] Serialize(CborBase data)
+    {
+        Type valueType = data.GetType().GetGenericArguments()[0];
+        PropertyInfo? valueProperty = data.GetType().GetProperties()
+            .FirstOrDefault(p => p.PropertyType == valueType && p.Name != nameof(CborBase.Raw))
+            ?? throw new InvalidOperationException($"No property of type {valueType.Name} found in Cbor object.");
+
+        object? value = valueProperty.GetValue(data);
+
+        if (value is null)
+        {
+            CborWriter writer = new();
+            writer.WriteNull();
+            return writer.Encode();
+        }
+        else
+        {
+            return CborSerializer.Serialize((CborBase)value);
+        }
+    }
+}

--- a/src/Chrysalis/Cbor/Types/Primitives/CborNullable.cs
+++ b/src/Chrysalis/Cbor/Types/Primitives/CborNullable.cs
@@ -1,0 +1,8 @@
+using Chrysalis.Cbor.Attributes;
+using Chrysalis.Cbor.Converters;
+using Chrysalis.Cbor.Converters.Primitives;
+
+namespace Chrysalis.Cbor.Types.Primitives;
+
+[CborConverter(typeof(NullableConverter))]
+public record CborNullable<T>(T? Value) : CborBase where T : CborBase;


### PR DESCRIPTION
This pull request implements the CborNullable primitive type to support nullable types in (de)serialization moving forward.