### PR TITLE
refactor: migrated custom types for Cardano (i.e. datums, redeemers) in Chrysalis

### DIFF
--- a/src/Chrysalis/Cardano/Coinecta/Types/Common/ClaimEntry.cs
+++ b/src/Chrysalis/Cardano/Coinecta/Types/Common/ClaimEntry.cs
@@ -1,0 +1,27 @@
+using Chrysalis.Cardano.Core.Types.Block.Transaction.Output;
+using Chrysalis.Cardano.Sundae.Types.Common;
+using Chrysalis.Cbor.Attributes;
+using Chrysalis.Cbor.Converters.Primitives;
+using Chrysalis.Cbor.Types;
+using Chrysalis.Cbor.Types.Primitives;
+
+namespace Chrysalis.Cardano.Coinecta.Types.Common;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(0)]
+public record ClaimEntry(
+    [CborProperty(0)]
+    MultisigScript Claimant,
+
+    [CborProperty(1)]
+    MultiAssetOutput VestingValue,
+
+    [CborProperty(2)]
+    MultiAssetOutput DirectValue,
+
+    [CborProperty(3)]
+    CborBytes VestingParameters,
+
+    [CborProperty(4)]
+    CborBytes VestingProgram
+) : CborBase;

--- a/src/Chrysalis/Cardano/Coinecta/Types/Datums/Treasury.cs
+++ b/src/Chrysalis/Cardano/Coinecta/Types/Datums/Treasury.cs
@@ -1,0 +1,21 @@
+using Chrysalis.Cardano.Core.Types.Primitives;
+using Chrysalis.Cardano.Sundae.Types.Common;
+using Chrysalis.Cbor.Attributes;
+using Chrysalis.Cbor.Converters.Primitives;
+using Chrysalis.Cbor.Types;
+using Chrysalis.Cbor.Types.Primitives;
+
+namespace Chrysalis.Cardano.Coinecta.Types.Datums;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(0)]
+public record Treasury(
+    [CborProperty(0)]
+    MultisigScript Owner,
+
+    [CborProperty(1)]
+    CborBytes TreasuryRootHash,
+
+    [CborProperty(2)]
+    PosixTime UnlockTime
+) : CborBase;

--- a/src/Chrysalis/Cardano/Coinecta/Types/Redeemers/TreasuryRedeemer.cs
+++ b/src/Chrysalis/Cardano/Coinecta/Types/Redeemers/TreasuryRedeemer.cs
@@ -1,0 +1,24 @@
+using Chrysalis.Cardano.Coinecta.Types.Common;
+using Chrysalis.Cardano.MPF.Types.Common;
+using Chrysalis.Cbor.Attributes;
+using Chrysalis.Cbor.Converters.Primitives;
+using Chrysalis.Cbor.Types;
+
+namespace Chrysalis.Cardano.Coinecta.Types.Redeemers;
+
+[CborConverter(typeof(UnionConverter))]
+public record TreasuryRedeemer : CborBase;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(0)]
+public record TreasuryClaimRedeemer(
+    [CborProperty(0)]
+    Proof Proof,
+
+    [CborProperty(1)]
+    ClaimEntry ClaimEntry
+) : TreasuryRedeemer;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(1)]
+public record TreasuryWithdrawRedeemer() : TreasuryRedeemer;

--- a/src/Chrysalis/Cardano/Core/Types/Primitives/CborBoundedBytes.cs
+++ b/src/Chrysalis/Cardano/Core/Types/Primitives/CborBoundedBytes.cs
@@ -1,0 +1,9 @@
+using Chrysalis.Cbor.Attributes;
+using Chrysalis.Cbor.Converters.Primitives;
+using Chrysalis.Cbor.Types;
+
+namespace Chrysalis.Cardano.Core.Types.Primitives;
+
+[CborConverter(typeof(BytesConverter))]
+[CborSize(64)]
+public record CborBoundedBytes(byte[] Value) : CborBase;

--- a/src/Chrysalis/Cardano/Core/Types/Primitives/PosixTime.cs
+++ b/src/Chrysalis/Cardano/Core/Types/Primitives/PosixTime.cs
@@ -1,0 +1,5 @@
+using Chrysalis.Cbor.Types.Primitives;
+
+namespace Chrysalis.Cardano.Core.Types.Primitives;
+
+public record PosixTime(ulong Value) : CborUlong(Value);

--- a/src/Chrysalis/Cardano/Jpg/Types/Common/ListingPayout.cs
+++ b/src/Chrysalis/Cardano/Jpg/Types/Common/ListingPayout.cs
@@ -1,0 +1,17 @@
+using Chrysalis.Cbor.Attributes;
+using Chrysalis.Cbor.Converters.Primitives;
+using Chrysalis.Cbor.Types;
+using Chrysalis.Cbor.Types.Primitives;
+using Chrysalis.Plutus.Types.Address;
+
+namespace Chrysalis.Cardano.Jpg.Types.Common;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(0)]
+public record ListingPayout(
+    [CborProperty(0)]
+    Address Address,
+
+    [CborProperty(1)]
+    CborUlong Amount
+) : CborBase;

--- a/src/Chrysalis/Cardano/Jpg/Types/Common/OfferPayout.cs
+++ b/src/Chrysalis/Cardano/Jpg/Types/Common/OfferPayout.cs
@@ -1,0 +1,20 @@
+using Chrysalis.Cbor.Attributes;
+using Chrysalis.Cbor.Converters.Primitives;
+using Chrysalis.Cbor.Types;
+using Chrysalis.Cbor.Types.Primitives;
+using Chrysalis.Plutus.Types.Address;
+
+namespace Chrysalis.Cardano.Jpg.Types.Common;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(0)]
+public record OfferPayout(
+    [CborProperty(0)]
+    Address Address,
+
+    [CborProperty(1)]
+    PayoutValue PayoutValue
+) : CborBase;
+
+[CborConverter(typeof(MapConverter))]
+public record PayoutValue(Dictionary<CborBytes, Token> Value) : CborBase;

--- a/src/Chrysalis/Cardano/Jpg/Types/Common/Token.cs
+++ b/src/Chrysalis/Cardano/Jpg/Types/Common/Token.cs
@@ -1,0 +1,17 @@
+using Chrysalis.Cbor.Attributes;
+using Chrysalis.Cbor.Converters.Primitives;
+using Chrysalis.Cbor.Types;
+using Chrysalis.Cbor.Types.Collections;
+using Chrysalis.Cbor.Types.Primitives;
+
+namespace Chrysalis.Cardano.Jpg.Types.Common;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(0)]
+public record Token(
+    [CborProperty(0)]
+    CborInt TokenType,
+
+    [CborProperty(1)]
+    CborMap<CborBytes, CborUlong> Amount
+) : CborBase;

--- a/src/Chrysalis/Cardano/Jpg/Types/Datums/Listing.cs
+++ b/src/Chrysalis/Cardano/Jpg/Types/Datums/Listing.cs
@@ -1,0 +1,21 @@
+
+using Chrysalis.Cbor.Attributes;
+using Chrysalis.Cbor.Converters.Primitives;
+using Chrysalis.Cbor.Types.Collections;
+using Chrysalis.Cbor.Types;
+using Chrysalis.Cbor.Types.Primitives;
+using Chrysalis.Cardano.Jpg.Types.Common;
+
+namespace Chrysalis.Cardano.Jpg.Types.Datums;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(0)]
+public record Listing(
+    [CborProperty(0)]
+    CborIndefList<ListingPayout> Payouts,
+
+    [CborProperty(1)]
+    CborBytes OwnerPkh
+) : CborBase;
+
+

--- a/src/Chrysalis/Cardano/Jpg/Types/Datums/Offer.cs
+++ b/src/Chrysalis/Cardano/Jpg/Types/Datums/Offer.cs
@@ -1,0 +1,19 @@
+using Chrysalis.Cardano.Core.Types.Block.Transaction.Output;
+using Chrysalis.Cbor.Attributes;
+using Chrysalis.Cbor.Converters.Primitives;
+using Chrysalis.Cbor.Types;
+using Chrysalis.Cbor.Types.Collections;
+using Chrysalis.Cbor.Types.Primitives;
+using Chrysalis.Cardano.Jpg.Types.Common;
+
+namespace Chrysalis.Cardano.Jpg.Types.Datums;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(0)]
+public record Offer(
+    [CborProperty(0)]
+    CborBytes OwnerPkh,
+
+    [CborProperty(1)]
+    CborIndefList<OfferPayout> Payouts
+) : CborBase;

--- a/src/Chrysalis/Cardano/Jpg/Types/Redeemers/BuyRedeemer.cs
+++ b/src/Chrysalis/Cardano/Jpg/Types/Redeemers/BuyRedeemer.cs
@@ -1,0 +1,13 @@
+using Chrysalis.Cbor.Attributes;
+using Chrysalis.Cbor.Converters.Primitives;
+using Chrysalis.Cbor.Types;
+using Chrysalis.Cbor.Types.Primitives;
+
+namespace Chrysalis.Cardano.Jpg.Types.Redeemers;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(0)]
+public record BuyRedeemer(
+    [CborProperty(0)]
+    CborInt Offset
+) : CborBase;

--- a/src/Chrysalis/Cardano/Levvy/TokenV2/Types/Datums/NftDatum.cs
+++ b/src/Chrysalis/Cardano/Levvy/TokenV2/Types/Datums/NftDatum.cs
@@ -1,0 +1,88 @@
+using Chrysalis.Cardano.Core.Types.Primitives;
+using Chrysalis.Cbor.Attributes;
+using Chrysalis.Cbor.Converters.Primitives;
+using Chrysalis.Cbor.Types;
+using Chrysalis.Cbor.Types.Primitives;
+using Chrysalis.Plutus.Types;
+using Chrysalis.Plutus.Types.Address;
+
+namespace Chrysalis.Cardano.Levvy.TokenV2.Types.Datums;
+
+[CborConverter(typeof(UnionConverter))]
+public record NftDatum() : CborBase;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(0)]
+public record LendNftDatum(LendNftDetails LendNftDetails) : NftDatum;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(1)]
+public record BorrowNftDatum(BorrowNftDetails BorrowNftDetails) : NftDatum;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(2)]
+public record RepayNftDatum(RepayNftDetails RepayNftDetails) : NftDatum;
+
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(0)]
+public record LendNftDetails(
+    [CborProperty(0)]
+    Address AdaOwner,
+
+    [CborProperty(1)]
+    CborBytes PolicyId,
+
+    [CborProperty(2)]
+    CborUlong LoanAmount,
+
+    [CborProperty(3)]
+    CborUlong InterestAmount,
+
+    [CborProperty(4)]
+    CborUlong LoanDuration
+) : CborBase;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(0)]
+public record BorrowNftDetails(
+    [CborProperty(0)]
+    Address AdaOwner,
+
+    [CborProperty(1)]
+    Address AssetOwner,
+
+    [CborProperty(2)]
+    CborBytes PolicyId,
+
+    [CborProperty(3)]
+    CborBytes AssetName,
+
+    [CborProperty(4)]
+    CborUlong LoanAmount,
+
+    [CborProperty(5)]
+    CborUlong InterestAmount,
+
+    [CborProperty(6)]
+    PosixTime LoanEndTime,
+
+    [CborProperty(7)]
+    OutputReference OutputReference
+) : CborBase;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(0)]
+public record RepayNftDetails(
+    [CborProperty(0)]
+    Address AdaOwner,
+
+    [CborProperty(1)]
+    CborUlong LoanAmount,
+
+    [CborProperty(2)]
+    CborUlong InterestAmount,
+
+    [CborProperty(3)]
+    OutputReference OutputReference
+) : CborBase;

--- a/src/Chrysalis/Cardano/Levvy/TokenV2/Types/Datums/PaymentDatum.cs
+++ b/src/Chrysalis/Cardano/Levvy/TokenV2/Types/Datums/PaymentDatum.cs
@@ -1,0 +1,11 @@
+using Chrysalis.Cbor;
+using Chrysalis.Cbor.Attributes;
+using Chrysalis.Cbor.Converters.Primitives;
+using Chrysalis.Cbor.Types;
+using Chrysalis.Plutus.Types;
+
+namespace Chrysalis.Cardano.Levvy.TokenV2.Types.Datums;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(0)]
+public record PaymentDatum(OutputReference OutputReference) : CborBase;

--- a/src/Chrysalis/Cardano/Levvy/TokenV2/Types/Datums/TokenDatum.cs
+++ b/src/Chrysalis/Cardano/Levvy/TokenV2/Types/Datums/TokenDatum.cs
@@ -1,0 +1,102 @@
+using Chrysalis.Cardano.Core.Types.Primitives;
+using Chrysalis.Cbor.Attributes;
+using Chrysalis.Cbor.Converters.Primitives;
+using Chrysalis.Cbor.Types;
+using Chrysalis.Cbor.Types.Primitives;
+using Chrysalis.Plutus.Types;
+using Chrysalis.Plutus.Types.Address;
+
+namespace Chrysalis.Cardano.Levvy.TokenV2.Types.Datums;
+
+[CborConverter(typeof(UnionConverter))]
+public record TokenDatum() : CborBase;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(0)]
+public record LendTokenDatum(LendTokenDetails LendTokenDetails) : TokenDatum;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(1)]
+public record BorrowTokenDatum(BorrowTokenDetails BorrowTokenDetails) : TokenDatum;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(2)]
+public record RepayTokenDatum(RepayTokenDetails RepayTokenDetails) : TokenDatum;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(0)]
+public record LendTokenDetails(
+    [CborProperty(0)]
+    Address AdaOwner,
+
+    [CborProperty(1)]
+    CborBytes PolicyId,
+
+    [CborProperty(2)]
+    CborBytes AssetName,
+
+    [CborProperty(3)]
+    CborUlong TokenAmount,
+
+    [CborProperty(4)]
+    CborUlong LoanAmount,
+
+    [CborProperty(5)]
+    CborUlong InterestAmount,
+
+    [CborProperty(6)]
+    CborUlong LoanDuration,
+
+    [CborProperty(7)]
+    OutputReference OutputReference
+) : CborBase;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(0)]
+public record BorrowTokenDetails(
+    [CborProperty(0)]
+    Address AdaOwner,
+
+    [CborProperty(1)]
+    Address AssetOwner,
+
+    [CborProperty(2)]
+    CborBytes PolicyId,
+
+    [CborProperty(3)]
+    CborBytes AssetName,
+
+    [CborProperty(4)]
+    CborUlong TokenAmount,
+
+    [CborProperty(5)]
+    CborUlong LoanAmount,
+
+    [CborProperty(6)]
+    CborUlong InterestAmount,
+
+    [CborProperty(7)]
+    PosixTime LoanEndTime,
+
+    [CborProperty(8)]
+    OutputReference OutputReference
+) : CborBase;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(0)]
+public record RepayTokenDetails(
+    [CborProperty(0)]
+    Address AdaOwner,
+
+    [CborProperty(1)]
+    CborUlong TokenAmount,
+
+    [CborProperty(2)]
+    CborUlong LoanAmount,
+
+    [CborProperty(3)]
+    CborUlong InterestAmount,
+
+    [CborProperty(4)]
+    OutputReference OutputReference
+) : CborBase;

--- a/src/Chrysalis/Cardano/Levvy/TokenV2/Types/Redeemers/TokenRedeemer.cs
+++ b/src/Chrysalis/Cardano/Levvy/TokenV2/Types/Redeemers/TokenRedeemer.cs
@@ -1,0 +1,30 @@
+using Chrysalis.Cbor;
+using Chrysalis.Cbor.Attributes;
+using Chrysalis.Cbor.Converters.Primitives;
+using Chrysalis.Cbor.Types;
+using Chrysalis.Plutus.Types;
+
+namespace Chrysalis.Cardano.Levvy.TokenV2.Types.Redeemers;
+
+[CborConverter(typeof(UnionConverter))]
+public record TokenRedeemer() : CborBase;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(0)]
+public record BorrowTokenAction() : TokenRedeemer;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(1)]
+public record RepayTokenAction() : TokenRedeemer;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(2)]
+public record ClaimTokenAction() : TokenRedeemer;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(3)]
+public record ForecloseTokenAction() : TokenRedeemer;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(4)]
+public record CancelTokenAction() : TokenRedeemer;

--- a/src/Chrysalis/Cardano/MPF/Types/Common/Proof.cs
+++ b/src/Chrysalis/Cardano/MPF/Types/Common/Proof.cs
@@ -1,0 +1,61 @@
+
+using Chrysalis.Cardano.Core.Types.Primitives;
+using Chrysalis.Cbor.Attributes;
+using Chrysalis.Cbor.Converters.Primitives;
+using Chrysalis.Cbor.Types;
+using Chrysalis.Cbor.Types.Collections;
+using Chrysalis.Cbor.Types.Primitives;
+
+namespace Chrysalis.Cardano.MPF.Types.Common;
+
+[CborConverter(typeof(UnionConverter))]
+public record ProofStep : CborBase;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(0)]
+public record Branch(
+    [CborProperty(0)]
+    CborUlong Skip,
+
+    [CborProperty(1)]
+    CborBoundedBytes Neighbors
+) : ProofStep;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(1)]
+public record Fork(
+    [CborProperty(0)]
+    CborUlong Skip,
+
+    [CborProperty(1)]
+    Neighbor Neighbor
+) : ProofStep;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(2)]
+public record Leaf(
+    [CborProperty(0)]
+    CborUlong Skip,
+
+    [CborProperty(1)]
+    CborBoundedBytes Key,
+
+    [CborProperty(2)]
+    CborBoundedBytes Value
+) : ProofStep;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(0)]
+public record Neighbor(
+    [CborProperty(0)]
+    CborUlong Nibble,
+
+    [CborProperty(1)]
+    CborBoundedBytes Prefix,
+
+    [CborProperty(2)]
+    CborBoundedBytes Root
+) : ProofStep;
+
+[CborConverter(typeof(ListConverter))]
+public record Proof(CborIndefList<ProofStep> ProofSteps) : CborBase;

--- a/src/Chrysalis/Cardano/Minswap/Types/Common/AssetClass.cs
+++ b/src/Chrysalis/Cardano/Minswap/Types/Common/AssetClass.cs
@@ -1,0 +1,16 @@
+using Chrysalis.Cbor.Attributes;
+using Chrysalis.Cbor.Converters.Primitives;
+using Chrysalis.Cbor.Types;
+using Chrysalis.Cbor.Types.Primitives;
+
+namespace Chrysalis.Cardano.Minswap.Types.Common;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(0)]
+public record AssetClass(
+    [CborProperty(0)]
+    CborBytes PolicyId,
+
+    [CborProperty(1)]
+    CborBytes AssetName
+) : CborBase;

--- a/src/Chrysalis/Cardano/Minswap/Types/Common/Bool.cs
+++ b/src/Chrysalis/Cardano/Minswap/Types/Common/Bool.cs
@@ -1,0 +1,16 @@
+using Chrysalis.Cbor.Attributes;
+using Chrysalis.Cbor.Converters.Primitives;
+using Chrysalis.Cbor.Types;
+
+namespace Chrysalis.Cardano.Minswap.Types.Common;
+
+[CborConverter(typeof(UnionConverter))]
+public record Bool: CborBase;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(0)]
+public record False: Bool;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(1)]
+public record True : Bool;

--- a/src/Chrysalis/Cardano/Minswap/Types/Datums/MinswapLiquidityPool.cs
+++ b/src/Chrysalis/Cardano/Minswap/Types/Datums/MinswapLiquidityPool.cs
@@ -1,0 +1,58 @@
+
+
+using Chrysalis.Cardano.Minswap.Types.Common;
+using Chrysalis.Cbor.Attributes;
+using Chrysalis.Cbor.Converters.Primitives;
+using Chrysalis.Cbor.Types;
+using Chrysalis.Cbor.Types.Functional;
+using Chrysalis.Cbor.Types.Primitives;
+using Chrysalis.Plutus.Types.Address;
+
+namespace Chrysalis.Cardano.Minswap.Types.Datums;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(0)]
+public record MinswapLiquidityPool(
+    [CborProperty(0)]
+    Inline<Credential> StakeCredential,
+    
+    [CborProperty(1)]
+    AssetClass AssetX,
+    
+    [CborProperty(2)]
+    AssetClass AssetY,
+    
+    [CborProperty(3)]
+    CborUlong total_liquidity,
+    
+    [CborProperty(4)]
+    CborUlong reserve_a,
+    
+    [CborProperty(5)]
+    CborUlong reserve_b,
+    
+    [CborProperty(6)]
+    CborUlong base_fee_a_numerator,
+
+    [CborProperty(7)]
+    CborUlong base_fee_b_numerator,
+    
+    [CborProperty(8)]
+    Option<CborUlong> fee_sharing_numerator_opt,
+
+    [CborProperty(9)]
+    Bool allow_dynamic_fee
+
+) : CborBase;
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/Chrysalis/Cardano/Splash/Types/Common/AssetClass.cs
+++ b/src/Chrysalis/Cardano/Splash/Types/Common/AssetClass.cs
@@ -1,0 +1,16 @@
+using Chrysalis.Cbor.Attributes;
+using Chrysalis.Cbor.Converters.Primitives;
+using Chrysalis.Cbor.Types;
+using Chrysalis.Cbor.Types.Primitives;
+
+namespace Chrysalis.Cardano.Splash.Types.Common;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(0)]
+public record AssetClass(
+    [CborProperty(0)]
+    CborBytes PolicyId,
+
+    [CborProperty(1)]
+    CborBytes AssetName
+) : CborBase;

--- a/src/Chrysalis/Cardano/Splash/Types/Datums/SplashLiquidityPool.cs
+++ b/src/Chrysalis/Cardano/Splash/Types/Datums/SplashLiquidityPool.cs
@@ -1,0 +1,47 @@
+using Chrysalis.Cardano.Splash.Types.Common;
+using Chrysalis.Cbor.Attributes;
+using Chrysalis.Cbor.Converters.Primitives;
+using Chrysalis.Cbor.Types;
+using Chrysalis.Cbor.Types.Collections;
+using Chrysalis.Cbor.Types.Primitives;
+using Chrysalis.Plutus.Types.Address;
+
+namespace Chrysalis.Cardano.Splash.Types.Datums;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(0)]
+public record SplashLiquidityPool(
+    [CborProperty(0)]
+    AssetClass PoolNft,
+    
+    [CborProperty(1)]
+    AssetClass AssetX,
+    
+    [CborProperty(2)]
+    AssetClass AssetY,
+    
+    [CborProperty(3)]
+    AssetClass AssetLq,
+    
+    [CborProperty(4)]
+    CborUlong Fee1,
+    
+    [CborProperty(5)]
+    CborUlong Fee2,
+    
+    [CborProperty(6)]
+    CborUlong Fee3,
+
+    [CborProperty(7)]
+    CborUlong Fee4,
+    
+    [CborProperty(8)]
+    CborMaybeIndefList<Inline<Credential>> Verification,
+
+    [CborProperty(9)]
+    CborUlong MarketOpen,
+
+    [CborProperty(10)]
+    CborBytes Last
+
+) : CborBase;

--- a/src/Chrysalis/Cardano/Sundae/Types/Common/AssetClass.cs
+++ b/src/Chrysalis/Cardano/Sundae/Types/Common/AssetClass.cs
@@ -1,0 +1,30 @@
+using Chrysalis.Cbor.Attributes;
+using Chrysalis.Cbor.Converters.Primitives;
+using Chrysalis.Cbor.Types;
+using Chrysalis.Cbor.Types.Collections;
+using Chrysalis.Cbor.Types.Primitives;
+
+namespace Chrysalis.Cardano.Sundae.Types.Common;
+
+
+[CborConverter(typeof(UnionConverter))]
+public abstract record AssetClass : CborBase;
+
+[CborConverter(typeof(ListConverter))]
+public record AssetClassIndefinite(List<CborBytes> Value) : AssetClass;
+
+[CborConverter(typeof(ListConverter))]
+[CborDefinite]
+public record AssetClassDefinite(List<CborBytes> Value) : AssetClass;
+
+
+
+[CborConverter(typeof(UnionConverter))]
+public abstract record AssetClassTuple : CborBase;
+
+[CborConverter(typeof(ListConverter))]
+public record AssetClassTupleIndef(List<AssetClass> Value) : AssetClassTuple;
+
+[CborConverter(typeof(ListConverter))]
+[CborDefinite]
+public record AssetClassTupleDef(List<AssetClass> Value) : AssetClassTuple;

--- a/src/Chrysalis/Cardano/Sundae/Types/Common/MultisigScript.cs
+++ b/src/Chrysalis/Cardano/Sundae/Types/Common/MultisigScript.cs
@@ -1,0 +1,39 @@
+using Chrysalis.Cardano.Core.Types.Primitives;
+using Chrysalis.Cbor.Attributes;
+using Chrysalis.Cbor.Converters.Primitives;
+using Chrysalis.Cbor.Types;
+using Chrysalis.Cbor.Types.Collections;
+using Chrysalis.Cbor.Types.Primitives;
+
+namespace Chrysalis.Cardano.Sundae.Types.Common;
+
+[CborConverter(typeof(UnionConverter))]
+public abstract record MultisigScript : CborBase;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(0)]
+public record Signature(CborBytes KeyHash) : MultisigScript;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(1)]
+public record AllOf(CborIndefList<MultisigScript> Scripts) : MultisigScript;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(2)]
+public record AnyOf(CborIndefList<MultisigScript> Scripts) : MultisigScript;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(3)]
+public record AtLeast(CborUlong Required, CborIndefList<MultisigScript> Scripts) : MultisigScript;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(4)]
+public record Before(PosixTime Time) : MultisigScript;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(5)]
+public record After(PosixTime Time) : MultisigScript;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(6)]
+public record Script(CborBytes ScriptHash) : MultisigScript;

--- a/src/Chrysalis/Cardano/Sundae/Types/Datums/SundaeSwapLiquidityPool.cs
+++ b/src/Chrysalis/Cardano/Sundae/Types/Datums/SundaeSwapLiquidityPool.cs
@@ -1,0 +1,36 @@
+using Chrysalis.Cardano.Sundae.Types.Common;
+using Chrysalis.Cbor.Attributes;
+using Chrysalis.Cbor.Converters.Primitives;
+using Chrysalis.Cbor.Types;
+using Chrysalis.Cbor.Types.Functional;
+using Chrysalis.Cbor.Types.Primitives;
+
+namespace Chrysalis.Cardano.Sundae.Types.Datums;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(0)]
+public record SundaeSwapLiquidityPool(
+    [CborProperty(0)]
+    CborBytes Identifier,
+    
+    [CborProperty(1)]
+    AssetClassTuple Assets,
+    
+    [CborProperty(2)]
+    CborUlong CirculatingLp,
+    
+    [CborProperty(3)]
+    CborUlong BidFeesPer10Thousand,
+    
+    [CborProperty(4)]
+    CborUlong AskFeesPer10Thousand,
+    
+    [CborProperty(5)]
+    Option<MultisigScript> FeeManager,
+    
+    [CborProperty(6)]
+    CborUlong MarketOpen,
+    
+    [CborProperty(7)]
+    CborUlong ProtocolFees
+) : CborBase;

--- a/src/Chrysalis/Plutus/Types/OutputReference.cs
+++ b/src/Chrysalis/Plutus/Types/OutputReference.cs
@@ -1,0 +1,20 @@
+using Chrysalis.Cbor.Attributes;
+using Chrysalis.Cbor.Converters.Primitives;
+using Chrysalis.Cbor.Types;
+using Chrysalis.Cbor.Types.Primitives;
+
+namespace Chrysalis.Plutus.Types;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(0)]
+public record OutputReference(
+    [CborProperty(0)]
+    TransactionId TransactionId,
+
+    [CborProperty(1)]
+    CborUlong Index
+) : CborBase;
+
+[CborConverter(typeof(ConstrConverter))]
+[CborIndex(0)]
+public record TransactionId(CborBytes Hash) : CborBase;


### PR DESCRIPTION
This pull request implemented and migrated the custom types (e.g. JPG, Minswap, Sundae, Splash, etc.) in Chrysalis.