### PR TITLE
docs: remove redundant description from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 <div align="center">
   <img src="assets/banner.png" alt="Chrysalis Banner" width="100%">
   
-  <p>A comprehensive .NET ecosystem for Cardano blockchain development</p>
-  
   <a href="https://www.nuget.org/packages/Chrysalis">
     <img src="https://img.shields.io/nuget/v/Chrysalis.svg?style=flat-square" alt="NuGet">
   </a>


### PR DESCRIPTION
The description 'A comprehensive .NET ecosystem for Cardano blockchain development' was redundant as it's already included in the banner image.

🤖 Generated with [Claude Code](https://claude.ai/code)