### PR TITLE
chore: bump version to 0.7.10 (#243)

### DIFF
--- a/src/Chrysalis.Cbor.CodeGen/Chrysalis.Cbor.CodeGen.csproj
+++ b/src/Chrysalis.Cbor.CodeGen/Chrysalis.Cbor.CodeGen.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>Latest</LangVersion>
-    <Version>0.7.9</Version>
+    <Version>0.7.10</Version>
     <PackageId>Chrysalis.Cbor.CodeGen</PackageId>
     <Authors>clark@saib.dev, rjlacanlale@saib.dev</Authors>
     <Company>SAIB Inc</Company>

--- a/src/Chrysalis/Chrysalis.csproj
+++ b/src/Chrysalis/Chrysalis.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>0.7.9</Version>
+    <Version>0.7.10</Version>
     <PackageId>Chrysalis</PackageId>
     <Authors>clark@saib.dev, rjlacanlale@saib.dev, rico.quiblat@saib.dev, wendellmor.tamayo@saib.dev, christian.gantuangco@saib.dev</Authors>
     <Company>SAIB Inc</Company>


### PR DESCRIPTION
## Summary
Bump version from 0.7.9 to 0.7.10 to include recent improvements.

## Changes included in this release
- fix(network): handle ChainSync tip state and N2C CBOR tag wrapping (#242)
- feat(plutus): support network-specific slot configurations (#241)
- refactor(tx): optimized byte array comparison and hex string caching (#238)
- feat(network): implement Chain-Sync MsgDone and improve protocol documentation (#240)

## Key improvements
- ChainSync now properly handles the chain tip state machine
- N2C CBOR tag 24 wrapping is handled transparently at the library level
- Enhanced Plutus VM with network-specific slot configurations
- Performance optimizations in transaction building

## Test Plan
- [x] Version updated in all relevant .csproj files
- [ ] Build passes
- [ ] NuGet package can be created successfully

🤖 Generated with [Claude Code](https://claude.ai/code)