### PR TITLE
fix(network): LocalStateQuery returns stale data during active ChainSync

### DIFF
--- a/src/Chrysalis.Network/MiniProtocols/LocalStateQuery.cs
+++ b/src/Chrysalis.Network/MiniProtocols/LocalStateQuery.cs
@@ -3,32 +3,62 @@ using Chrysalis.Network.Multiplexer;
 using Chrysalis.Cbor.Serialization;
 using Chrysalis.Network.Cbor.LocalStateQuery;
 using Chrysalis.Network.Cbor.Common;
+using Chrysalis.Cbor.Types;
 
 namespace Chrysalis.Network.MiniProtocols;
 
-public class LocalStateQuery(AgentChannel channel)
+public class LocalStateQuery(AgentChannel channel) : IAsyncDisposable
 {
     private readonly ChannelBuffer _buffer = new(channel);
 
-    // States
-    private bool IsAcquired = false;
+    // State management
+    private bool _isAcquired = false;
 
-    public async Task<Result> QueryAsync(Point? point, QueryReq query, CancellationToken cancellationToken)
+    public bool IsAcquired => _isAcquired;
+
+    public async Task<Result> QueryAsync(QueryReq query, CancellationToken cancellationToken)
     {
-        if (!IsAcquired)
+        if (!_isAcquired)
         {
-            await _buffer.SendFullMessageAsync(AcquireTypes.Default(point), cancellationToken);
-            LocalStateQueryMessage acquireResponse = await _buffer.ReceiveFullMessageAsync<LocalStateQueryMessage>(cancellationToken);
-
-            if (acquireResponse is not Acquired)
-            {
-                throw new Exception("Failed to acquire");
-            }
-
-            IsAcquired = true;
+            throw new InvalidOperationException("Must acquire state before querying. Call AcquireAsync first.");
         }
 
         await _buffer.SendFullMessageAsync(QueryRequest.New(query), cancellationToken);
         return await _buffer.ReceiveFullMessageAsync<Result>(cancellationToken);
+    }
+
+    public async Task AcquireAsync(Point? point, CancellationToken cancellationToken)
+    {
+        await _buffer.SendFullMessageAsync(AcquireTypes.Default(point), cancellationToken);
+        LocalStateQueryMessage acquireResponse = await _buffer.ReceiveFullMessageAsync<LocalStateQueryMessage>(cancellationToken);
+
+        if (acquireResponse is not Acquired)
+        {
+            throw new Exception($"Failed to acquire state: {acquireResponse}");
+        }
+
+        _isAcquired = true;
+    }
+
+    public async Task ReleaseAsync(CancellationToken cancellationToken)
+    {
+        if (_isAcquired)
+        {
+            await _buffer.SendFullMessageAsync(new Release(new Value5(5)), cancellationToken);
+            _isAcquired = false;
+        }
+    }
+
+
+    public async ValueTask DisposeAsync()
+    {
+        try
+        {
+            await ReleaseAsync(CancellationToken.None);
+        }
+        catch
+        {
+            // Best effort cleanup
+        }
     }
 }


### PR DESCRIPTION
## Summary

This PR fixes an issue where `LocalStateQuery` returns stale tip data when `ChainSync` is actively syncing on the same `NodeClient` connection.

## Problem

The `LocalStateQuery` mini-protocol was maintaining a persistent "acquired" state that never reset, causing it to return stale data. When used alongside active `ChainSync`, all queries after the initial acquisition would use outdated chain state, violating the Ouroboros protocol design where mini-protocols should operate independently.

## Solution

- Made `AcquireAsync`, `ReleaseAsync`, and `IsAcquired` public for direct protocol control
- Updated `QueryAsync` to be a raw protocol method that requires prior state acquisition
- Updated all extension methods to follow the pattern: check state → release if needed → acquire → query → release
- Added `ExecuteWithFreshStateAsync` helper to encapsulate the pattern and reduce code duplication
- Ensured protocol compliance by checking `IsAcquired` before releasing (respects the Ouroboros state machine)
- Removed unnecessary async wrappers for better performance

## Test Plan

- [x] Run the included CLI test program that demonstrates concurrent ChainSync and tip queries
- [x] Verify tip queries return fresh data (slot numbers increase) while ChainSync is active
- [x] Ensure no protocol violations occur (no Release from Idle state)
- [ ] Test with other LocalStateQuery operations (GetUtxosByAddress, etc.)

## Breaking Changes

- `QueryAsync` now requires explicit state acquisition (throws if not acquired)
- `QueryAsync` no longer takes a `Point?` parameter - the point is specified during acquisition

🤖 Generated with [Claude Code](https://claude.ai/code)