### PR TITLE
chore: bump version to v0.7.15

### DIFF
--- a/src/Chrysalis.Cbor.CodeGen/Chrysalis.Cbor.CodeGen.csproj
+++ b/src/Chrysalis.Cbor.CodeGen/Chrysalis.Cbor.CodeGen.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>Latest</LangVersion>
-    <Version>0.7.14</Version>
+    <Version>0.7.15</Version>
     <PackageId>Chrysalis.Cbor.CodeGen</PackageId>
     <Authors>clark@saib.dev, rjlacanlale@saib.dev</Authors>
     <Company>SAIB Inc</Company>

--- a/src/Chrysalis/Chrysalis.csproj
+++ b/src/Chrysalis/Chrysalis.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>0.7.14</Version>
+    <Version>0.7.15</Version>
     <PackageId>Chrysalis</PackageId>
     <Authors>clark@saib.dev, rjlacanlale@saib.dev, rico.quiblat@saib.dev, wendellmor.tamayo@saib.dev, christian.gantuangco@saib.dev</Authors>
     <Company>SAIB Inc</Company>


### PR DESCRIPTION
## Summary

Bump version to v0.7.15 to prepare for the next release.

## Changes included since v0.7.14

- fix(tx): move fee buffer assignment after calculating requirements (#254)

## Test plan

- [x] Version numbers updated in all project files
- [ ] Build and publish to NuGet after merge

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>