### PR TITLE
chore: bump version to v0.7.16

### DIFF
--- a/src/Chrysalis/Chrysalis.csproj
+++ b/src/Chrysalis/Chrysalis.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>0.7.15</Version>
+    <Version>0.7.16</Version>
     <PackageId>Chrysalis</PackageId>
     <Authors>clark@saib.dev, rjlacanlale@saib.dev, rico.quiblat@saib.dev, wendellmor.tamayo@saib.dev, christian.gantuangco@saib.dev</Authors>
     <Company>SAIB Inc</Company>


### PR DESCRIPTION
## Summary
- Bumps version from v0.7.15 to v0.7.16
- Includes new feature: Kupo provider for UTXO querying (#257)

## Release Notes
When this PR is merged and tagged as v0.7.16, GitHub will auto-generate the changelog from the following conventional commits:

- feat(tx): Add Kupo provider for UTXO querying (#257)

## Test plan
- [x] Version number updated in Chrysalis.csproj
- [ ] CI tests pass
- [ ] Ready for release tag after merge

🤖 Generated with [Claude Code](https://claude.ai/code)