### PR TITLE
chore: bump version to v0.7.16

### DIFF
--- a/src/Chrysalis.Cbor.CodeGen/Chrysalis.Cbor.CodeGen.csproj
+++ b/src/Chrysalis.Cbor.CodeGen/Chrysalis.Cbor.CodeGen.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>Latest</LangVersion>
-    <Version>0.7.15</Version>
+    <Version>0.7.16</Version>
     <PackageId>Chrysalis.Cbor.CodeGen</PackageId>
     <Authors>clark@saib.dev, rjlacanlale@saib.dev</Authors>
     <Company>SAIB Inc</Company>

--- a/src/Chrysalis/Chrysalis.csproj
+++ b/src/Chrysalis/Chrysalis.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>0.7.15</Version>
+    <Version>0.7.16</Version>
     <PackageId>Chrysalis</PackageId>
     <Authors>clark@saib.dev, rjlacanlale@saib.dev, rico.quiblat@saib.dev, wendellmor.tamayo@saib.dev, christian.gantuangco@saib.dev</Authors>
     <Company>SAIB Inc</Company>


### PR DESCRIPTION
## Summary
- Bumps version from v0.7.15 to v0.7.16 for both:
  - Chrysalis package
  - Chrysalis.Cbor.CodeGen package
- Includes new feature: Kupo provider for UTXO querying (#257)

## Release Notes
When this PR is merged and tagged as v0.7.16, GitHub will auto-generate the changelog from the following conventional commits since v0.7.15:

- feat(tx): Add Kupo provider for UTXO querying (#257)

## Test plan
- [x] Version numbers updated in both project files
- [ ] CI tests pass
- [ ] Ready for release tag after merge

🤖 Generated with [Claude Code](https://claude.ai/code)