### PR TITLE
chore: bump version to v0.7.18

### DIFF
--- a/src/Chrysalis.Cbor.CodeGen/Chrysalis.Cbor.CodeGen.csproj
+++ b/src/Chrysalis.Cbor.CodeGen/Chrysalis.Cbor.CodeGen.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>Latest</LangVersion>
-    <Version>0.7.17</Version>
+    <Version>0.7.18</Version>
     <PackageId>Chrysalis.Cbor.CodeGen</PackageId>
     <Authors>clark@saib.dev, rjlacanlale@saib.dev</Authors>
     <Company>SAIB Inc</Company>

--- a/src/Chrysalis/Chrysalis.csproj
+++ b/src/Chrysalis/Chrysalis.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>0.7.17</Version>
+    <Version>0.7.18</Version>
     <PackageId>Chrysalis</PackageId>
     <Authors>clark@saib.dev, rjlacanlale@saib.dev, rico.quiblat@saib.dev, wendellmor.tamayo@saib.dev, christian.gantuangco@saib.dev</Authors>
     <Company>SAIB Inc</Company>


### PR DESCRIPTION
## Summary
- Bumps version from v0.7.17 to v0.7.18 for both:
  - Chrysalis package
  - Chrysalis.Cbor.CodeGen package

## Changes since v0.7.17
- fix: correct Rust library reference from pallas to plutus_vm (#264)
  - Fixed incorrect library reference in project files
  - Updated Rust dependencies (chrono, uplc)
  - Modernized CI/CD with dtolnay/rust-toolchain

## Test plan
- [x] Version numbers updated in both project files
- [ ] CI tests pass
- [ ] Ready for release tag after merge

🤖 Generated with [Claude Code](https://claude.ai/code)