### PR TITLE
fix(cbor): Add required field validation to CBOR deserialization

### DIFF
--- a/src/Chrysalis.Cbor.CodeGen/CborSerializerCodeGen.Metadata.cs
+++ b/src/Chrysalis.Cbor.CodeGen/CborSerializerCodeGen.Metadata.cs
@@ -118,6 +118,7 @@ public sealed partial class CborSerializerCodeGen
         // Attributes
         public bool IsNullable { get; } = isNullable;
         public bool IsTypeNullable => PropertyType.Contains("?");
+        public bool IsRequired => !IsTypeNullable && !IsNullable;
         public int? Size { get; } = size;
         public bool IsIndefinite { get; } = isIndefinite;
         public int? Order { get; set; } = order;

--- a/src/Chrysalis.Cbor.Test/Chrysalis.Test.csproj
+++ b/src/Chrysalis.Cbor.Test/Chrysalis.Test.csproj
@@ -32,6 +32,9 @@
 
   <ItemGroup>
     <ProjectReference Include="../Chrysalis.Cbor/Chrysalis.Cbor.csproj" />
+    <ProjectReference Include="../Chrysalis.Cbor.CodeGen/Chrysalis.Cbor.CodeGen.csproj" 
+              OutputItemType="Analyzer" 
+              ReferenceOutputAssembly="false" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

- Implements validation for required fields during CBOR deserialization
- Adds `IsRequired` property to identify non-nullable fields without `[CborNullable]` attribute
- Generates field tracking arrays and validation logic during code generation
- Throws descriptive exceptions when required fields are missing from CBOR data

## Key Changes

- **`CborSerializerCodeGen.Metadata.cs`**: Added `IsRequired` property to `SerializablePropertyMetadata`
- **`CborSerializerCodeGen.ReadEmitter.cs`**: Enhanced `EmitCustomListReader` with field tracking and validation
- **Test Infrastructure**: Added CodeGen project reference and cleaned up commented code

## Implementation Details

The fix works by:
1. **Analysis**: Identifying required fields using `!IsTypeNullable && !IsNullable` 
2. **Tracking**: Generating `bool[] fieldsRead` arrays to track which fields were present
3. **Validation**: Checking that all required fields were read and throwing exceptions for missing ones
4. **Optimization**: Only generates tracking code when types actually have required fields

## Test Coverage

- All existing tests pass (no regressions)
- Generated code includes proper validation (verified in `BabbageBlock.Serializer.g.cs`)
- Performance optimized to only add overhead when needed

## Before/After

**Before**: Missing required fields silently get default values  
**After**: Missing required fields throw descriptive exceptions like:
```
"Required field 'FieldName' is missing from CBOR data"
```

Closes #256

🤖 Generated with [Claude Code](https://claude.ai/code)