### PR TITLE
chore: bump version to v0.7.19

### DIFF
--- a/src/Chrysalis.Cbor.CodeGen/Chrysalis.Cbor.CodeGen.csproj
+++ b/src/Chrysalis.Cbor.CodeGen/Chrysalis.Cbor.CodeGen.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>Latest</LangVersion>
-    <Version>0.7.18</Version>
+    <Version>0.7.19</Version>
     <PackageId>Chrysalis.Cbor.CodeGen</PackageId>
     <Authors>clark@saib.dev, rjlacanlale@saib.dev</Authors>
     <Company>SAIB Inc</Company>

--- a/src/Chrysalis.Cbor.Test/DatumTests.cs
+++ b/src/Chrysalis.Cbor.Test/DatumTests.cs
@@ -142,10 +142,10 @@ public class DatumTests
         Assert.Equal(1076872000UL, poolDatum.ProtocolFees);
         // Verify fee manager
         Assert.IsType<Some<MultisigScript>>(poolDatum.FeeManager);
-        Some<MultisigScript> feeManager = poolDatum.FeeManager as Some<MultisigScript>;
+        Some<MultisigScript> feeManager = (poolDatum.FeeManager as Some<MultisigScript>)!;
         Assert.NotNull(feeManager);
         Assert.IsType<Signature>(feeManager.Value);
-        Signature signature = feeManager.Value as Signature;
+        Signature signature = (feeManager.Value as Signature)!;
         Assert.Equal("0bc4df2c05da7920fe0825b68f83fd96d84f215da6ef360f7057ad83", Convert.ToHexString(signature.KeyHash).ToLowerInvariant());
     }
     [Theory]

--- a/src/Chrysalis.Cbor/Chrysalis.Cbor.csproj
+++ b/src/Chrysalis.Cbor/Chrysalis.Cbor.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>0.6.0</Version>
+    <Version>0.7.19</Version>
     <PackageId>Chrysalis.Cbor</PackageId>
     <Authors>clark@saib.dev, rjlacanlale@saib.dev, kathea.mayol@saib.dev</Authors>
     <Company>SAIB Inc</Company>

--- a/src/Chrysalis.Plutus/Chrysalis.Plutus.csproj
+++ b/src/Chrysalis.Plutus/Chrysalis.Plutus.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
-    <Version>0.1.0</Version>
+    <Version>0.7.19</Version>
   </PropertyGroup>
 
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">

--- a/src/Chrysalis/Chrysalis.csproj
+++ b/src/Chrysalis/Chrysalis.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>0.7.18</Version>
+    <Version>0.7.19</Version>
     <PackageId>Chrysalis</PackageId>
     <Authors>clark@saib.dev, rjlacanlale@saib.dev, rico.quiblat@saib.dev, wendellmor.tamayo@saib.dev, christian.gantuangco@saib.dev</Authors>
     <Company>SAIB Inc</Company>


### PR DESCRIPTION
## Summary
- Update all package versions to v0.7.19 for consistency across Chrysalis components
- Fix nullable reference warnings in DatumTests.cs with null-forgiving operators
- Align Plutus component version with main ecosystem (was 0.1.0, now 0.7.19)

## Changes
- Chrysalis.Cbor: 0.6.0 → 0.7.19
- Chrysalis.Cbor.CodeGen: 0.7.18 → 0.7.19  
- Chrysalis: 0.7.18 → 0.7.19
- Chrysalis.Plutus: 0.1.0 → 0.7.19

## Rationale
This version bump follows the successful integration of:
- CborLabel and CborPrimitive types for COSE RFC 8152 support
- Enhanced schema validation and required field validation
- Conway era compliance features

🤖 Generated with [Claude Code](https://claude.ai/code)