### PR TITLE
chore(release): bump version to v0.7.21

### DIFF
--- a/src/Chrysalis.Cbor.CodeGen/Chrysalis.Cbor.CodeGen.csproj
+++ b/src/Chrysalis.Cbor.CodeGen/Chrysalis.Cbor.CodeGen.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>Latest</LangVersion>
-    <Version>0.7.20</Version>
+    <Version>0.7.21</Version>
     <PackageId>Chrysalis.Cbor.CodeGen</PackageId>
     <Authors>clark@saib.dev, rjlacanlale@saib.dev</Authors>
     <Company>SAIB Inc</Company>

--- a/src/Chrysalis.Plutus/Chrysalis.Plutus.csproj
+++ b/src/Chrysalis.Plutus/Chrysalis.Plutus.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
-    <Version>0.7.20</Version>
+    <Version>0.7.21</Version>
   </PropertyGroup>
 
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">

--- a/src/Chrysalis/Chrysalis.csproj
+++ b/src/Chrysalis/Chrysalis.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>0.7.20</Version>
+    <Version>0.7.21</Version>
     <PackageId>Chrysalis</PackageId>
     <Authors>clark@saib.dev, rjlacanlale@saib.dev, rico.quiblat@saib.dev, wendellmor.tamayo@saib.dev, christian.gantuangco@saib.dev</Authors>
     <Company>SAIB Inc</Company>


### PR DESCRIPTION
## Summary
- raise Chrysalis, Plutus, and Cbor.CodeGen package versions to 0.7.21
- prepare patch release for the CIP-8 checksum parser fix

## Testing
- not run (metadata-only changes)