### PR TITLE
chore(release): bump version to v1.0.4-alpha

### DIFF
--- a/src/Chrysalis.Cbor.CodeGen/Chrysalis.Cbor.CodeGen.csproj
+++ b/src/Chrysalis.Cbor.CodeGen/Chrysalis.Cbor.CodeGen.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>Latest</LangVersion>
-    <Version>1.0.3-alpha</Version>
+    <Version>1.0.4-alpha</Version>
     <PackageId>Chrysalis.Cbor.CodeGen</PackageId>
     <Authors>clark@saib.dev, rjlacanlale@saib.dev</Authors>
     <Company>SAIB Inc</Company>

--- a/src/Chrysalis.Plutus/Chrysalis.Plutus.csproj
+++ b/src/Chrysalis.Plutus/Chrysalis.Plutus.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
-    <Version>1.0.3-alpha</Version>
+    <Version>1.0.4-alpha</Version>
   </PropertyGroup>
 
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">

--- a/src/Chrysalis/Chrysalis.csproj
+++ b/src/Chrysalis/Chrysalis.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>1.0.3-alpha</Version>
+    <Version>1.0.4-alpha</Version>
     <PackageId>Chrysalis</PackageId>
     <Authors>clark@saib.dev, rjlacanlale@saib.dev, rico.quiblat@saib.dev, wendellmor.tamayo@saib.dev, christian.gantuangco@saib.dev</Authors>
     <Company>SAIB Inc</Company>


### PR DESCRIPTION
## Summary
- Bump version from `1.0.3-alpha` to `1.0.4-alpha` in:
  - `src/Chrysalis/Chrysalis.csproj`
  - `src/Chrysalis.Plutus/Chrysalis.Plutus.csproj`
  - `src/Chrysalis.Cbor.CodeGen/Chrysalis.Cbor.CodeGen.csproj`

## Changes in this release
- feat(tx): add methods to retrieve UTXOs by payment key and payment keys (#293)

🤖 Generated with [Claude Code](https://claude.com/claude-code)