### PR TITLE
fix(tx): scope refScriptFee to the tx's declared reference inputs

### DIFF
--- a/src/Chrysalis.Tx/Builders/TxBuilder.cs
+++ b/src/Chrysalis.Tx/Builders/TxBuilder.cs
@@ -938,16 +938,36 @@ public class TxBuilder
 
         bool hasScripts = builder.Redeemers is not null;
 
-        // Pre-compute reference script fee from reference inputs on the builder
+        // Pre-compute reference script fee from the tx's declared
+        // reference inputs. The prior implementation summed every ScriptRef
+        // it saw in `allUtxos`, which wrongly billed ref-script fees for
+        // dormant script-ref UTxOs at the change address (e.g. a wallet
+        // that happens to hold deployed reference scripts was paying
+        // tens of ADA on every ordinary payment). Per Cardano ledger:
+        // refScriptFee is computed only over scripts referenced by
+        // `tx.reference_inputs`.
         ulong refScriptFee = 0;
-        if (_pparams.MinFeeRefScriptCostPerByte is not null)
+        if (_pparams.MinFeeRefScriptCostPerByte is not null
+            && builder.ReferenceInputs is { Count: > 0 } referenceInputs)
         {
             ulong scriptCostPerByte = _pparams.MinFeeRefScriptCostPerByte.Numerator
                 / _pparams.MinFeeRefScriptCostPerByte.Denominator;
-            int totalScriptSize = 0;
-            foreach (ResolvedInput refInput in allUtxos)
+
+            HashSet<(string, ulong)> referenced = new(referenceInputs.Count);
+            foreach (TransactionInput r in referenceInputs)
             {
-                ReadOnlyMemory<byte>? scriptRef = refInput.Output.ScriptRef();
+                _ = referenced.Add((Convert.ToHexStringLower(r.TransactionId.Span), r.Index));
+            }
+
+            int totalScriptSize = 0;
+            foreach (ResolvedInput utxo in allUtxos)
+            {
+                string txHash = Convert.ToHexStringLower(utxo.Outref.TransactionId.Span);
+                if (!referenced.Contains((txHash, utxo.Outref.Index)))
+                {
+                    continue;
+                }
+                ReadOnlyMemory<byte>? scriptRef = utxo.Output.ScriptRef();
                 if (scriptRef is not null)
                 {
                     totalScriptSize += scriptRef.Value.Length;


### PR DESCRIPTION
## Summary

`TxBuilder.Finalize` was summing the `ScriptRef` of every UTxO it had fetched — i.e. every UTxO at the change address — when computing `refScriptFee`, not just the UTxOs listed in `tx.reference_inputs`. On any wallet that happened to hold a deployed reference-script UTxO, ordinary transactions were being billed tens of ADA of phantom fees.

Observed in the wild: a 459-byte pure-payment tx against a wallet holding 3 deployed Sundae/wizard reference scripts computed a fee of **32.51 ADA** (expected ~0.18 ADA). Ledger spec scopes refScriptFee to `tx.reference_inputs` only.

The fix builds a `HashSet<(txHash, index)>` from `builder.ReferenceInputs` and skips UTxOs whose outref isn't present before summing script sizes.

## Related issues

None filed — discovered while wiring CIP-30 user-signed swaps in a downstream demo.

## Testing performed

- Existing suite: all 1191 tests pass (`dotnet test`)
- Manual verification against the downstream demo wallet (`addr_test1qpacwpy…qqjp7hr`) holding 3 ref-script UTxOs:
  - Before patch: `fee = 32.51 ADA` for a 459B swap-order tx
  - After patch: `fee = 0.18 ADA`, tx confirms on preprod

## Test plan

- [x] `dotnet build` succeeds
- [x] `dotnet test` passes
- [x] Manual E2E on preprod with downstream demo (user-signed CIP-30 swap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)