### PR TITLE
docs: drop --generate-notes from release CLI step to avoid doubled body

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,11 +181,13 @@ After approval, merge the PR into `main`.
 ```bash
 gh release create v1.0.X-alpha \
   --title "v1.0.X-alpha" \
-  --generate-notes \
-  --prerelease
+  --prerelease \
+  --notes ""
 ```
 
-The tag triggers the release workflow, which builds, tests, packs, and publishes the packages. The `--generate-notes` flag automatically creates a changelog from merged PRs since the last release.
+Leave the body empty — the release workflow's `softprops/action-gh-release` step runs on the tag push and populates the release notes via GitHub's auto-changelog. Passing `--generate-notes` here would double the body because the workflow would then append a second copy.
+
+The tag also triggers build, test, pack, and publish of all packages.
 
 #### 6. Verify CI/CD
 


### PR DESCRIPTION
## Summary

v1.7.9-alpha shipped with its changelog printed twice — `## What's Changed` appeared twice in the release body.

Root cause: two notes generators run back-to-back:
1. The CLI step in CONTRIBUTING: `gh release create … --generate-notes` writes the notes at creation time.
2. The release workflow's `softprops/action-gh-release@v2` has `generate_release_notes: true` and re-writes notes on tag push, appending to the existing body.

Removing `--generate-notes` from the CLI step and passing `--notes ""` makes the workflow's auto-changelog the single source of truth. The v1.7.9-alpha body has already been manually deduplicated.

## Testing

Flow going forward:
```
gh release create v1.7.X-alpha --title "v1.7.X-alpha" --prerelease --notes ""
```
Tag push → workflow fires → softprops fills notes once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)