### PR TITLE
feat(network): N2N chain-sync support + unify N2C/N2N RollForward (breaking rename)

### DIFF
--- a/benchmarks/PallasChainSyncBench/Cargo.lock
+++ b/benchmarks/PallasChainSyncBench/Cargo.lock
@@ -63,9 +63,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bech32"
-version = "0.9.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
+checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 
 [[package]]
 name = "bitflags"
@@ -108,6 +108,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,6 +137,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crc"
@@ -224,7 +244,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -265,17 +285,6 @@ checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "getrandom"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
@@ -283,6 +292,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "rand_core",
  "wasip2",
  "wasip3",
 ]
@@ -516,7 +526,7 @@ checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -578,9 +588,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "pallas"
-version = "1.0.0-alpha.5"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ed55bb2e520bf2b05e51a68e2d7503d07dea829e2de613ba8f415b4ab5f7bf"
+checksum = "48773d1214fa3e3a4d79f08eac74e3bfdad67c1e441c5817696cb42f34cbf138"
 dependencies = [
  "pallas-addresses",
  "pallas-codec",
@@ -596,9 +606,9 @@ dependencies = [
 
 [[package]]
 name = "pallas-addresses"
-version = "1.0.0-alpha.5"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d900cf15d2287228751d719c906f5fd6da2a1b9ab0790786ba984f3e24857cd0"
+checksum = "1c3988277ebfa1c7efde42fb2382deebe80aa3f321fd5d2e87ef5ee9dfc7b685"
 dependencies = [
  "base58",
  "bech32",
@@ -621,9 +631,9 @@ dependencies = [
 
 [[package]]
 name = "pallas-codec"
-version = "1.0.0-alpha.5"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420460d5e76f20097d1c8e110c54ff5165f9805a1ebe72b92cebcaafd81d62ae"
+checksum = "8dc8ec5e664aa50ae954c3e5d7d4887ab2b21cdf016a10422c0b2c97e7558686"
 dependencies = [
  "hex",
  "minicbor",
@@ -633,9 +643,9 @@ dependencies = [
 
 [[package]]
 name = "pallas-configs"
-version = "1.0.0-alpha.5"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a655731b2380478240adbf40c4d037ced0b2bb6865dd08dc117cd3422ae14eb"
+checksum = "f96807d2c3418d53031ca80a29c778951efa572f5f4aff85265ff6a64dfebe19"
 dependencies = [
  "base64 0.22.1",
  "num-rational",
@@ -649,31 +659,31 @@ dependencies = [
 
 [[package]]
 name = "pallas-crypto"
-version = "1.0.0-alpha.5"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad8225947795b2d5ff42e187445036d566f4a16ce1e6f610eb85086c14afb027"
+checksum = "c62f08aa8af671cd4ebb41081b6ea857077b0587ffde16a640bd8f2af0e86b5d"
 dependencies = [
  "cryptoxide",
  "hex",
  "pallas-codec",
- "rand_core 0.9.5",
+ "rand_core",
  "serde",
  "thiserror",
 ]
 
 [[package]]
 name = "pallas-network"
-version = "1.0.0-alpha.5"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c902b84184fa16800eecea5f30f1d710ba0e7d6a8e6a16b108a00d6d67b510f4"
+checksum = "aad130ec8195018a8308f63130c5bf49abdc5531efe7431257fb0278336adaa6"
 dependencies = [
  "byteorder",
  "hex",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "pallas-codec",
  "pallas-crypto",
  "rand",
- "socket2 0.5.10",
+ "socket2",
  "thiserror",
  "tokio",
  "tracing",
@@ -681,9 +691,9 @@ dependencies = [
 
 [[package]]
 name = "pallas-primitives"
-version = "1.0.0-alpha.5"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d88a593a989176e95ffd2b05b385e492db54df4b389d1a9ddf4b4bfa741676"
+checksum = "cac94485435820b8765c87e9f2c5167ba4729f56117a669aba5a3e4c4f522545"
 dependencies = [
  "hex",
  "pallas-codec",
@@ -694,12 +704,12 @@ dependencies = [
 
 [[package]]
 name = "pallas-traverse"
-version = "1.0.0-alpha.5"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e2ab4191f1ad628e3527c54a11cad30148ce100644615fe6d9d70b7a75ed81"
+checksum = "f917f26d63e1e014d5ea1fc734307ea3a688b74991fe2eddee64a73c3ab15aaf"
 dependencies = [
  "hex",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "pallas-addresses",
  "pallas-codec",
  "pallas-crypto",
@@ -711,9 +721,9 @@ dependencies = [
 
 [[package]]
 name = "pallas-txbuilder"
-version = "1.0.0-alpha.5"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "039ba172071ff5b55213825aef4d833f80243c2c06840e2dd90911ea4cca0946"
+checksum = "7b97e466b38c75a8725fab9ca619c17cb66c09ab356f8e85bfe041f5e3c34e49"
 dependencies = [
  "hex",
  "pallas-addresses",
@@ -728,9 +738,9 @@ dependencies = [
 
 [[package]]
 name = "pallas-utxorpc"
-version = "1.0.0-alpha.5"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa8ce9978e1b9020a37b568eaaceb1dbc47fd92fd3d0a9422ef2f04a8a73909c"
+checksum = "c59b43ca1414603cc6d011c854f49afe3afbda60f39f90dae6f2879883cc84aa"
 dependencies = [
  "pallas-codec",
  "pallas-crypto",
@@ -743,9 +753,9 @@ dependencies = [
 
 [[package]]
 name = "pallas-validate"
-version = "1.0.0-alpha.5"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c72fc97c8b651db355aa0046337f23d27e6f680e6ffe87ebe0e17ca114238dbc"
+checksum = "881df106d3b758f62105245b5e27b98766f1dc64f309115c60a8700ba85c3ea6"
 dependencies = [
  "chrono",
  "hex",
@@ -852,15 +862,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -948,39 +949,20 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "libc",
- "rand_chacha",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
+ "chacha20",
+ "getrandom",
+ "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "ref-cast"
@@ -1041,7 +1023,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1172,22 +1154,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
-dependencies = [
- "libc",
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1214,26 +1186,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1282,9 +1254,9 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.2",
+ "socket2",
  "tokio-macros",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1387,9 +1359,9 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "utxorpc-spec"
-version = "0.18.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e59de89d0dfd8e594377b53a8f67a10de01bb63b15b169248760188fa06fb92a"
+checksum = "aa35373e6fbf0ea73651328aecd1641f92684de54bd908e3aa9855866b1c9875"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1565,159 +1537,12 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"

--- a/benchmarks/PallasChainSyncBench/Cargo.toml
+++ b/benchmarks/PallasChainSyncBench/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2021"
 publish = false
 
 [dependencies]
-pallas = "1.0.0-alpha.4"
+pallas = "1.1.0"
 hex = "0.4.3"
 tokio = { version = "1.27.0", features = ["rt-multi-thread", "macros", "signal"] }

--- a/src/Chrysalis.Codec.CodeGen/CborSerializerCodeGen.cs
+++ b/src/Chrysalis.Codec.CodeGen/CborSerializerCodeGen.cs
@@ -27,11 +27,32 @@ public sealed partial class CborSerializerCodeGen : IIncrementalGenerator
         context.RegisterSourceOutput(combined, EmitSerializersAndMetadata);
     }
 
+    /// <summary>
+    /// Registry of all serializable types in the current compilation, keyed by normalized
+    /// fully-qualified name. Populated before emission so the union emitter can classify the
+    /// CBOR shape of a member's property when that property is itself a generated record
+    /// (e.g. resolve a <c>[CborList]</c> record to an array) — needed for secondary structural
+    /// probing when union members share a leading index.
+    /// </summary>
+    internal static IReadOnlyDictionary<string, SerializableTypeMetadata> TypeRegistry { get; private set; }
+        = new Dictionary<string, SerializableTypeMetadata>();
+
+    /// <summary>
+    /// Normalizes a fully-qualified type name for registry keys and lookups by stripping the
+    /// <c>global::</c> prefix, nullable annotations, and surrounding whitespace.
+    /// </summary>
+    internal static string NormalizeTypeName(string fullyQualifiedName) =>
+        fullyQualifiedName.Replace("global::", "").Replace("?", "").Trim();
+
     private static void EmitSerializersAndMetadata(SourceProductionContext context, (Compilation compilation, ImmutableArray<TypeDeclarationSyntax> types) source)
     {
         Compilation compilation = source.compilation;
         ImmutableArray<TypeDeclarationSyntax> types = source.types;
 
+        // First pass: parse every serializable type and build the registry. We parse once here
+        // and emit from the parsed list below, so each type is parsed a single time.
+        List<SerializableTypeMetadata> parsed = [];
+        Dictionary<string, SerializableTypeMetadata> registry = [];
         foreach (TypeDeclarationSyntax type in types)
         {
             SemanticModel semanticModel = compilation.GetSemanticModel(type.SyntaxTree);
@@ -39,8 +60,17 @@ public sealed partial class CborSerializerCodeGen : IIncrementalGenerator
 
             if (metadata is not null)
             {
-                Emitter.EmitSerializerAndMetadata(context, metadata);
+                parsed.Add(metadata);
+                registry[NormalizeTypeName(metadata.FullyQualifiedName)] = metadata;
             }
+        }
+
+        TypeRegistry = registry;
+
+        // Second pass: emit serializers and metadata with the registry available.
+        foreach (SerializableTypeMetadata metadata in parsed)
+        {
+            Emitter.EmitSerializerAndMetadata(context, metadata);
         }
     }
 }

--- a/src/Chrysalis.Codec.CodeGen/Emitters/UnionEmitter.cs
+++ b/src/Chrysalis.Codec.CodeGen/Emitters/UnionEmitter.cs
@@ -99,9 +99,34 @@ public sealed partial class CborSerializerCodeGen
                 group.Add(child);
             }
 
-            if (probeGroups.ContainsKey("unknown") || probeGroups.Values.Any(g => g.Count > 1))
+            if (probeGroups.ContainsKey("unknown"))
             {
                 return false;
+            }
+
+            // Same-index collisions: members that share a leading index but differ in a deeper
+            // field. Rather than dropping the whole union to fragile try/catch, resolve the
+            // colliding members with a secondary structural probe on the first field whose CBOR
+            // shape distinguishes them. Only the index-discriminated case is handled here; a
+            // collision under any other top-level discriminator still falls back.
+            if (probeGroups.Values.Any(g => g.Count > 1))
+            {
+                bool allIdx = probeGroups.Keys.All(k => k.StartsWith("idx:", StringComparison.Ordinal));
+                if (!allIdx)
+                {
+                    return false;
+                }
+
+                foreach (List<SerializableTypeMetadata> colliding in probeGroups.Values.Where(g => g.Count > 1))
+                {
+                    if (FindSeparatingDepth(colliding) < 0)
+                    {
+                        return false;
+                    }
+                }
+
+                EmitIdxBranchWithNesting(sb, metadata, probeGroups);
+                return true;
             }
 
             bool hasTagChildren = probeGroups.Keys.Any(k => k.StartsWith("tag:", StringComparison.Ordinal));
@@ -199,6 +224,168 @@ public sealed partial class CborSerializerCodeGen
             _ = sb.AppendLine("};");
             _ = sb.AppendLine($"return _idxResult;");
         }
+
+        /// <summary>
+        /// Emits an index switch where each colliding index group (more than one member sharing a
+        /// leading index) is routed to a generated local function that resolves the variant by a
+        /// secondary structural probe. Non-colliding indices read their single member directly.
+        /// </summary>
+        private static void EmitIdxBranchWithNesting(StringBuilder sb, SerializableTypeMetadata metadata, Dictionary<string, List<SerializableTypeMetadata>> probeGroups)
+        {
+            // Emit one resolver local function per colliding index group.
+            Dictionary<string, string> resolvers = [];
+            foreach (KeyValuePair<string, List<SerializableTypeMetadata>> group in probeGroups.Where(g => g.Value.Count > 1))
+            {
+                int idxValue = int.Parse(group.Key.Substring(4), CultureInfo.InvariantCulture);
+                string resolverName = $"_ResolveIdx{idxValue}";
+                EmitSecondaryProbeLocalFunction(sb, metadata, resolverName, group.Value);
+                resolvers[group.Key] = resolverName;
+            }
+
+            _ = sb.AppendLine($"var _idxReader = new CborReader(data.Span);");
+            _ = sb.AppendLine($"_idxReader.ReadBeginArray();");
+            _ = sb.AppendLine($"_idxReader.ReadSize();");
+            _ = sb.AppendLine($"int _idx = _idxReader.ReadInt32();");
+            _ = sb.AppendLine($"{metadata.FullyQualifiedName} _idxResult = _idx switch");
+            _ = sb.AppendLine("{");
+            foreach (KeyValuePair<string, List<SerializableTypeMetadata>> group in probeGroups)
+            {
+                int idxValue = int.Parse(group.Key.Substring(4), CultureInfo.InvariantCulture);
+                _ = group.Value.Count == 1
+                    ? sb.AppendLine($"    {idxValue} => ({metadata.FullyQualifiedName}){group.Value[0].FullyQualifiedName}.Read(data, out bytesConsumed),")
+                    : sb.AppendLine($"    {idxValue} => {resolvers[group.Key]}(data, out bytesConsumed),");
+            }
+            _ = sb.AppendLine($"    _ => throw new Exception(\"Union deserialization failed. {metadata.FullyQualifiedName}: unexpected idx \" + _idx)");
+            _ = sb.AppendLine("};");
+            _ = sb.AppendLine($"return _idxResult;");
+        }
+
+        /// <summary>
+        /// Emits a local function that resolves between members sharing a leading index by reading
+        /// the CBOR data-item type of the first field that distinguishes them (skipping any
+        /// semantic tag), then dispatching to the matching member's reader.
+        /// </summary>
+        private static void EmitSecondaryProbeLocalFunction(StringBuilder sb, SerializableTypeMetadata metadata, string resolverName, List<SerializableTypeMetadata> members)
+        {
+            int depth = FindSeparatingDepth(members);
+
+            _ = sb.AppendLine($"{metadata.FullyQualifiedName} {resolverName}(ReadOnlyMemory<byte> _d, out int _bc)");
+            _ = sb.AppendLine("{");
+            _ = sb.AppendLine($"var _pr = new CborReader(_d.Span);");
+            _ = sb.AppendLine($"_pr.ReadBeginArray();");
+            _ = sb.AppendLine($"_pr.ReadSize();");
+            for (int i = 0; i < depth; i++)
+            {
+                _ = sb.AppendLine($"_pr.ReadDataItem();");
+            }
+            _ = sb.AppendLine($"var _shape = _pr.GetCurrentDataItemType();");
+            _ = sb.AppendLine($"{metadata.FullyQualifiedName} _r = _shape switch");
+            _ = sb.AppendLine("{");
+            foreach (SerializableTypeMetadata member in members)
+            {
+                string statePattern = GetCborReaderStatePattern(ClassifyProbeAtDepth(member, depth));
+                _ = sb.AppendLine($"    {statePattern} => ({metadata.FullyQualifiedName}){member.FullyQualifiedName}.Read(_d, out _bc),");
+            }
+            _ = sb.AppendLine($"    _ => throw new Exception(\"Union deserialization failed. {metadata.FullyQualifiedName}: ambiguous variant at shared index\")");
+            _ = sb.AppendLine("};");
+            _ = sb.AppendLine($"return _r;");
+            _ = sb.AppendLine("}");
+        }
+
+        /// <summary>
+        /// Returns the shallowest field depth (>= 1) at which the given members have pairwise
+        /// distinct, known CBOR shapes, or -1 if no field separates them structurally.
+        /// </summary>
+        private static int FindSeparatingDepth(List<SerializableTypeMetadata> members)
+        {
+            int maxDepth = members.Min(m => m.Properties.Count);
+            for (int depth = 1; depth < maxDepth; depth++)
+            {
+                List<string> keys = [.. members.Select(m => ClassifyProbeAtDepth(m, depth))];
+                if (keys.Any(k => k == "unknown"))
+                {
+                    continue;
+                }
+                if (keys.Distinct().Count() == keys.Count)
+                {
+                    return depth;
+                }
+            }
+            return -1;
+        }
+
+        /// <summary>
+        /// Classifies the CBOR data-item shape of the field at the given CBOR order within a
+        /// member, as a probe key understood by <see cref="GetCborReaderStatePattern"/>.
+        /// </summary>
+        private static string ClassifyProbeAtDepth(SerializableTypeMetadata member, int depth)
+        {
+            List<SerializablePropertyMetadata> ordered = [.. member.Properties.OrderBy(p => p.Order ?? int.MaxValue)];
+            return depth < 0 || depth >= ordered.Count
+                ? "unknown"
+                : ClassifyPropertyShape(ordered[depth]);
+        }
+
+        /// <summary>
+        /// Maps a property to the CBOR data-item shape it deserializes from. Tag-wrapped values
+        /// (e.g. <c>CborEncodedValue</c>) resolve to their inner shape because
+        /// <c>GetCurrentDataItemType</c> skips semantic tags.
+        /// </summary>
+        private static string ClassifyPropertyShape(SerializablePropertyMetadata prop)
+        {
+            string cleanType = NormalizeTypeName(prop.PropertyTypeFullName);
+
+            if (cleanType is "Chrysalis.Codec.Types.CborEncodedValue" or "CborEncodedValue")
+            {
+                return "bytes";
+            }
+            if (prop.IsList)
+            {
+                return "array";
+            }
+            if (prop.IsMap)
+            {
+                return "map";
+            }
+
+            switch (cleanType)
+            {
+                case "string":
+                    return "text";
+                case "bool":
+                    return "boolean";
+                case "byte[]":
+                case "ReadOnlyMemory<byte>":
+                case "System.ReadOnlyMemory<byte>":
+                    return "bytes";
+                case "int":
+                case "long":
+                case "uint":
+                case "ulong":
+                    return "integer";
+                default:
+                    break;
+            }
+
+            return TypeRegistry.TryGetValue(cleanType, out SerializableTypeMetadata? typeMeta) && typeMeta is not null
+                ? ClassifyTypeShape(typeMeta)
+                : "unknown";
+        }
+
+        /// <summary>
+        /// Maps a record type to the CBOR data-item shape it serializes as, ignoring any semantic
+        /// tag (which <c>GetCurrentDataItemType</c> skips). Constr types encode as a (possibly
+        /// tagged) array.
+        /// </summary>
+        private static string ClassifyTypeShape(SerializableTypeMetadata meta) => meta.SerializationType switch
+        {
+            SerializationType.List => "array",
+            SerializationType.Constr => "array",
+            SerializationType.Map => "map",
+            SerializationType.Container => "unknown",
+            SerializationType.Union => "unknown",
+            _ => "unknown"
+        };
 
         private static void EmitArraySizeBranch(StringBuilder sb, SerializableTypeMetadata metadata, Dictionary<string, List<SerializableTypeMetadata>> probeGroups)
         {

--- a/src/Chrysalis.Codec.Test/SecondaryProbeUnionTests.cs
+++ b/src/Chrysalis.Codec.Test/SecondaryProbeUnionTests.cs
@@ -1,0 +1,137 @@
+using Chrysalis.Codec.Serialization;
+using Chrysalis.Codec.Serialization.Attributes;
+using Chrysalis.Codec.Types;
+
+namespace Chrysalis.Codec.Test;
+
+// Isolated coverage for the union secondary structural probe: two union members that share the
+// same leading index (CborIndex 2) but differ in the CBOR shape of a later field — one carries a
+// tag-24 byte string (CborEncodedValue), the other a CBOR array (a [CborList] record). The engine
+// must resolve them by probing that field's shape instead of dropping the whole union to try/catch.
+// This mirrors the N2N/N2C RollForward case in Chrysalis.Network.
+
+/// <summary>An array-shaped payload: [era, #6.24(body)].</summary>
+[CborSerializable]
+[CborList]
+public partial record ProbeHeaderPayload(
+    [CborOrder(0)] int Era,
+    [CborOrder(1)] CborEncodedValue Body
+) : ICborType
+{
+    public ReadOnlyMemory<byte> Raw { get; set; }
+    public int ConstrIndex { get; set; }
+    public bool IsIndefinite { get; set; }
+}
+
+[CborSerializable]
+[CborUnion]
+public abstract partial record ProbeResponse : ICborType
+{
+    public ReadOnlyMemory<byte> Raw { get; set; }
+    public int ConstrIndex { get; set; }
+    public bool IsIndefinite { get; set; }
+}
+
+/// <summary>Singleton index 1.</summary>
+[CborSerializable]
+[CborList]
+[CborIndex(1)]
+public partial record ProbeAwait(
+    [CborOrder(0)] int Idx
+) : ProbeResponse;
+
+/// <summary>Index 2, payload is a tag-24 byte string -> resolves via ByteString.</summary>
+[CborSerializable]
+[CborList]
+[CborIndex(2)]
+public partial record ProbeForwardBytes(
+    [CborOrder(0)] int Idx,
+    [CborOrder(1)] CborEncodedValue Payload,
+    [CborOrder(2)] int Tip
+) : ProbeResponse;
+
+/// <summary>Index 2, payload is an array -> resolves via Array. Shares the index with ProbeForwardBytes.</summary>
+[CborSerializable]
+[CborList]
+[CborIndex(2)]
+public partial record ProbeForwardArray(
+    [CborOrder(0)] int Idx,
+    [CborOrder(1)] ProbeHeaderPayload Payload,
+    [CborOrder(2)] int Tip
+) : ProbeResponse;
+
+/// <summary>Singleton index 3.</summary>
+[CborSerializable]
+[CborList]
+[CborIndex(3)]
+public partial record ProbeBack(
+    [CborOrder(0)] int Idx,
+    [CborOrder(1)] int Point
+) : ProbeResponse;
+
+public class SecondaryProbeUnionTests
+{
+    private static readonly byte[] BodyBytes = Convert.FromHexString("DEADBEEF");
+
+    [Fact]
+    public void SharedIndex_BytesPayload_ResolvesToByteStringMember()
+    {
+        ProbeForwardBytes original = new(2, new CborEncodedValue(BodyBytes), 99);
+        byte[] bytes = CborSerializer.Serialize(original);
+
+        ProbeResponse decoded = CborSerializer.Deserialize<ProbeResponse>(bytes);
+
+        ProbeForwardBytes typed = Assert.IsType<ProbeForwardBytes>(decoded);
+        Assert.Equal(99, typed.Tip);
+        Assert.Equal(Convert.ToHexString(BodyBytes), Convert.ToHexString(typed.Payload.Value.ToArray()));
+    }
+
+    [Fact]
+    public void SharedIndex_ArrayPayload_ResolvesToArrayMember()
+    {
+        ProbeForwardArray original = new(2, new ProbeHeaderPayload(6, new CborEncodedValue(BodyBytes)), 99);
+        byte[] bytes = CborSerializer.Serialize(original);
+
+        ProbeResponse decoded = CborSerializer.Deserialize<ProbeResponse>(bytes);
+
+        ProbeForwardArray typed = Assert.IsType<ProbeForwardArray>(decoded);
+        Assert.Equal(6, typed.Payload.Era);
+        Assert.Equal(99, typed.Tip);
+    }
+
+    [Fact]
+    public void Singleton_Index1_StillDispatchesByIndex()
+    {
+        ProbeAwait original = new(1);
+        byte[] bytes = CborSerializer.Serialize(original);
+
+        ProbeResponse decoded = CborSerializer.Deserialize<ProbeResponse>(bytes);
+
+        _ = Assert.IsType<ProbeAwait>(decoded);
+    }
+
+    [Fact]
+    public void Singleton_Index3_StillDispatchesByIndex()
+    {
+        ProbeBack original = new(3, 12345);
+        byte[] bytes = CborSerializer.Serialize(original);
+
+        ProbeResponse decoded = CborSerializer.Deserialize<ProbeResponse>(bytes);
+
+        ProbeBack typed = Assert.IsType<ProbeBack>(decoded);
+        Assert.Equal(12345, typed.Point);
+    }
+
+    [Fact]
+    public void BothSharedIndexVariants_RoundTrip()
+    {
+        ProbeForwardBytes a = new(2, new CborEncodedValue(BodyBytes), 1);
+        ProbeForwardArray b = new(2, new ProbeHeaderPayload(7, new CborEncodedValue(BodyBytes)), 2);
+
+        ProbeResponse da = CborSerializer.Deserialize<ProbeResponse>(CborSerializer.Serialize(a));
+        ProbeResponse db = CborSerializer.Deserialize<ProbeResponse>(CborSerializer.Serialize(b));
+
+        _ = Assert.IsType<ProbeForwardBytes>(da);
+        _ = Assert.IsType<ProbeForwardArray>(db);
+    }
+}

--- a/src/Chrysalis.Network.Cli/Program.cs
+++ b/src/Chrysalis.Network.Cli/Program.cs
@@ -18,6 +18,7 @@ internal static class Program
     private const int DefaultKeepAliveSeconds = 20;
     private const int DefaultBlockCount = 100;
     private const int DefaultPipelineDepth = 50;
+    private const int BlockFetchBatch = 100; // headers collected then fetched per batch; matches Pallas bench default
 
     private sealed record Options(
         string Command,
@@ -29,6 +30,7 @@ internal static class Program
         int BlockCount,
         int PipelineDepth,
         bool HeadersOnly,
+        bool SingleFetch,
         ulong? Slot,
         string? Hash
     );
@@ -115,7 +117,7 @@ internal static class Program
 
             switch (response)
             {
-                case MessageRollForward rollForward:
+                case N2CMessageRollForward rollForward:
                     atTip = false;
                     totalBlocks++;
                     windowBlocks++;
@@ -207,7 +209,7 @@ internal static class Program
 
                 switch (response)
                 {
-                    case MessageRollForward rollForward:
+                    case N2NMessageRollForward rollForward:
                         tipPoint = rollForward.Tip.Slot;
                         ExtractHeaderPoint(rollForward, out Point? headerPoint);
                         if (headerPoint is not null)
@@ -220,7 +222,7 @@ internal static class Program
                         }
                         else
                         {
-                            Console.WriteLine($"  WARN: skipped unparseable header (payload {rollForward.Payload.Value.Length} bytes)");
+                            Console.WriteLine($"  WARN: skipped unparseable header (payload {rollForward.Payload.HeaderCbor.Value.Length} bytes)");
                         }
                         break;
                     case MessageRollBackward rollBackward:
@@ -334,12 +336,12 @@ internal static class Program
                         Console.WriteLine($"rollback to {FormatPoint(rollBackward.Point)}");
                     }
 
-                    if (response is MessageRollForward rollForward)
+                    if (response is N2NMessageRollForward rollForward)
                     {
                         tipPoint = rollForward.Tip.Slot;
                     }
 
-                    if (response is MessageRollForward or MessageRollBackward)
+                    if (response is N2NMessageRollForward or MessageRollBackward)
                     {
                         tipBackoffLogged = false;
                         break;
@@ -388,7 +390,8 @@ internal static class Program
             ? Point.Specific(options.Slot.Value, Convert.FromHexString(options.Hash))
             : Point.Origin;
 
-        Console.WriteLine($"BlockFetch: syncing headers from {FormatPoint(startPoint)}, then fetching {options.BlockCount} blocks...");
+        string mode = options.SingleFetch ? "single" : "range";
+        Console.WriteLine($"BlockFetch ({mode}): {options.BlockCount} blocks from {FormatPoint(startPoint)} (batch {BlockFetchBatch})...");
 
         ChainSyncMessage intersect = await peer.ChainSync.FindIntersectionAsync([startPoint], ct).ConfigureAwait(false);
         if (intersect is not MessageIntersectFound)
@@ -397,39 +400,7 @@ internal static class Program
             return 2;
         }
 
-        // Collect header points via ChainSync
-        List<Point> points = [];
-        while (points.Count < options.BlockCount && !ct.IsCancellationRequested)
-        {
-            MessageNextResponse? response = await peer.ChainSync.NextRequestAsync(ct).ConfigureAwait(false);
-            switch (response)
-            {
-                case MessageRollForward rollForward:
-                    ExtractHeaderPoint(rollForward, out Point? headerPoint);
-                    if (headerPoint is not null)
-                    {
-                        points.Add(headerPoint);
-                    }
-                    break;
-                case MessageRollBackward:
-                    break;
-                case MessageAwaitReply:
-                    Console.WriteLine("Reached chain tip during header collection.");
-                    goto fetchBlocks;
-                default:
-                    break;
-            }
-        }
-
-    fetchBlocks:
-        if (points.Count == 0)
-        {
-            Console.WriteLine("No headers collected.");
-            return 2;
-        }
-
-        Console.WriteLine($"Collected {points.Count} headers. Fetching blocks...");
-
+        // Timer covers the whole collect+fetch loop (excludes connect + intersect), matching Pallas's total_timer.
         Stopwatch timer = Stopwatch.StartNew();
         Stopwatch windowTimer = Stopwatch.StartNew();
         int totalFetched = 0;
@@ -437,32 +408,83 @@ internal static class Program
         Era lastEra = Era.Byron;
         ulong lastSlot = 0;
         ulong lastHeight = 0;
+        bool atTip = false;
 
-        // Fetch in batches using FetchRangeAsync (start..end of each batch)
-        int batchSize = Math.Min(100, points.Count);
-        for (int i = 0; i < points.Count && !ct.IsCancellationRequested; i += batchSize)
+        void Record(BlockWithEra block)
         {
-            int end = Math.Min(i + batchSize - 1, points.Count - 1);
-            await foreach (BlockWithEra block in peer.BlockFetch.FetchRangeAsync<BlockWithEra>(points[i], points[end], ct).ConfigureAwait(false))
+            totalFetched++;
+            windowFetched++;
+
+            if (block.Block is not null)
             {
-                totalFetched++;
-                windowFetched++;
+                lastEra = block.Era();
+                lastSlot = block.Block.Slot();
+                lastHeight = block.Block.Height();
+            }
 
-                if (block.Block is not null)
+            if (windowTimer.Elapsed.TotalSeconds >= 3)
+            {
+                double blkPerSec = windowFetched / windowTimer.Elapsed.TotalSeconds;
+                Console.WriteLine(
+                    $"[{timer.Elapsed:hh\\:mm\\:ss}] slot {lastSlot,10} block {lastHeight,8} [{lastEra,-10}] | " +
+                    $"{blkPerSec,7:F1} blk/s | {totalFetched}/{options.BlockCount} fetched");
+                windowTimer.Restart();
+                windowFetched = 0;
+            }
+        }
+
+        // Interleave header collection and block fetch in batches — identical structure to the Pallas
+        // benchmark (collect a batch of header points via ChainSync, then fetch that batch). The only
+        // difference between the modes is single (one RequestRange per block) vs range (one per batch).
+        while (totalFetched < options.BlockCount && !atTip && !ct.IsCancellationRequested)
+        {
+            int target = Math.Min(BlockFetchBatch, options.BlockCount - totalFetched);
+            List<Point> batch = new(target);
+
+            while (batch.Count < target && !ct.IsCancellationRequested)
+            {
+                MessageNextResponse? response = await peer.ChainSync.NextRequestAsync(ct).ConfigureAwait(false);
+                if (response is N2NMessageRollForward rollForward)
                 {
-                    lastEra = block.Era();
-                    lastSlot = block.Block.Slot();
-                    lastHeight = block.Block.Height();
+                    ExtractHeaderPoint(rollForward, out Point? headerPoint);
+                    if (headerPoint is not null)
+                    {
+                        batch.Add(headerPoint);
+                    }
                 }
-
-                if (windowTimer.Elapsed.TotalSeconds >= 3)
+                else if (response is MessageAwaitReply)
                 {
-                    double blkPerSec = windowFetched / windowTimer.Elapsed.TotalSeconds;
-                    Console.WriteLine(
-                        $"[{timer.Elapsed:hh\\:mm\\:ss}] slot {lastSlot,10} block {lastHeight,8} [{lastEra,-10}] | " +
-                        $"{blkPerSec,7:F1} blk/s | {totalFetched}/{points.Count} fetched");
-                    windowTimer.Restart();
-                    windowFetched = 0;
+                    atTip = true;
+                    break;
+                }
+            }
+
+            if (batch.Count == 0)
+            {
+                break;
+            }
+
+            if (options.SingleFetch)
+            {
+                foreach (Point point in batch)
+                {
+                    if (ct.IsCancellationRequested)
+                    {
+                        break;
+                    }
+
+                    BlockWithEra? block = await peer.BlockFetch.FetchSingleAsync<BlockWithEra>(point, ct).ConfigureAwait(false);
+                    if (block is { } fetched)
+                    {
+                        Record(fetched);
+                    }
+                }
+            }
+            else
+            {
+                await foreach (BlockWithEra block in peer.BlockFetch.FetchRangeAsync<BlockWithEra>(batch[0], batch[^1], ct).ConfigureAwait(false))
+                {
+                    Record(block);
                 }
             }
         }
@@ -481,12 +503,13 @@ internal static class Program
         return 0;
     }
 
-    private static void ExtractHeaderPoint(MessageRollForward rollForward, out Point? point)
+    private static void ExtractHeaderPoint(N2NMessageRollForward rollForward, out Point? point)
     {
         point = null;
         try
         {
-            ChainSyncHeader header = ChainSyncHeader.Decode(rollForward.Payload.Value);
+            // N2N RollForward payload is the typed [era, #6.24(header)]; decode the header for its point.
+            ChainSyncHeader header = new((byte)rollForward.Payload.EraTag, null, rollForward.Payload.HeaderCbor.Value);
             ChainPoint cp = header.ExtractPoint();
             point = Point.Specific(cp.Slot, cp.Hash);
         }
@@ -500,7 +523,7 @@ internal static class Program
 
     #region Formatting
 
-    private static void ExtractBlockInfo(MessageRollForward rollForward, ref Era era, ref ulong slot, ref ulong blockNumber)
+    private static void ExtractBlockInfo(N2CMessageRollForward rollForward, ref Era era, ref ulong slot, ref ulong blockNumber)
     {
         try
         {
@@ -593,7 +616,7 @@ internal static class Program
 
         HashSet<string> flags = new(StringComparer.OrdinalIgnoreCase);
         Dictionary<string, string> map = new(StringComparer.OrdinalIgnoreCase);
-        HashSet<string> booleanFlags = new(StringComparer.OrdinalIgnoreCase) { "headers-only" };
+        HashSet<string> booleanFlags = new(StringComparer.OrdinalIgnoreCase) { "headers-only", "single" };
 
         for (int i = startIdx; i < args.Length; i++)
         {
@@ -639,6 +662,7 @@ internal static class Program
             DefaultBlockCount, "block count", ref error);
         int pipelineDepth = ParseInt(GetValue(map, "pipeline"), DefaultPipelineDepth, "pipeline depth", ref error);
         bool headersOnly = flags.Contains("headers-only");
+        bool singleFetch = flags.Contains("single");
 
         ulong? slot = null;
         string? hash = null;
@@ -660,7 +684,7 @@ internal static class Program
             return false;
         }
 
-        options = new Options(command, socket, host, port, magic, keepAlive, blockCount, pipelineDepth, headersOnly, slot, hash);
+        options = new Options(command, socket, host, port, magic, keepAlive, blockCount, pipelineDepth, headersOnly, singleFetch, slot, hash);
         return true;
     }
 

--- a/src/Chrysalis.Network.Tests/N2NRollForwardCborTests.cs
+++ b/src/Chrysalis.Network.Tests/N2NRollForwardCborTests.cs
@@ -1,0 +1,101 @@
+using Chrysalis.Codec.Serialization;
+using Chrysalis.Codec.Types;
+using Chrysalis.Network.Cbor.ChainSync;
+using Chrysalis.Network.Cbor.Common;
+using Xunit;
+
+namespace Chrysalis.Network.Tests;
+
+/// <summary>
+/// Deserialization tests for the unified ChainSync next-response union — no node, no multiplexer,
+/// just bytes. N2C and N2N RollForward share chain-sync index 2 inside a single
+/// <see cref="MessageNextResponse"/> union; the serializer's structural probe resolves them by the
+/// payload's CBOR shape: a tag-24 block (<see cref="N2CMessageRollForward"/>) vs. an
+/// <c>[era, #6.24(header)]</c> array (<see cref="N2NMessageRollForward"/>).
+/// </summary>
+public class N2NRollForwardCborTests
+{
+    // A 32-byte stand-in for header/block content (real payloads are larger; shape is what matters).
+    private static readonly byte[] HeaderBytes =
+        Convert.FromHexString("7EF942E6A670AF6310737E9230B22E11A4BB1AF69BED9AFFB09B1025B371D1CD");
+
+    // The N2N payload: 82 (array2) 06 (era=6 Conway) D818 (tag24) 5820 (bstr len 32) <32 bytes>.
+    private static byte[] BuildN2nPayload() =>
+        [0x82, 0x06, 0xD8, 0x18, 0x58, 0x20, .. HeaderBytes];
+
+    [Fact]
+    public void N2NBlockHeader_DeserializesCleanly_AsArrayEraPlusEncodedHeader()
+    {
+        byte[] payload = BuildN2nPayload();
+
+        N2NBlockHeader decoded = CborSerializer.Deserialize<N2NBlockHeader>(payload);
+
+        Assert.Equal(6, decoded.EraTag);
+        Assert.Equal(
+            Convert.ToHexString(HeaderBytes),
+            Convert.ToHexString(decoded.HeaderCbor.Value.ToArray()));
+    }
+
+    [Fact]
+    public void SharedUnion_ResolvesN2NRollForward_ByArrayPayload()
+    {
+        Tip tip = new(Point.Specific(126025649UL, HeaderBytes), 4833605);
+        N2NMessageRollForward original = new(2, new N2NBlockHeader(6, new CborEncodedValue(HeaderBytes)), tip);
+        byte[] bytes = CborSerializer.Serialize(original);
+
+        // Deserialize against the SHARED union — the structural probe must pick the N2N (array) member.
+        MessageNextResponse decoded = CborSerializer.Deserialize<MessageNextResponse>(bytes);
+
+        N2NMessageRollForward typed = Assert.IsType<N2NMessageRollForward>(decoded);
+        Assert.Equal(6, typed.Payload.EraTag);
+        Assert.Equal(126025649UL, ((SpecificPoint)typed.Tip.Slot).Slot);
+    }
+
+    [Fact]
+    public void SharedUnion_ResolvesN2CRollForward_ByTag24Payload()
+    {
+        Tip tip = new(Point.Specific(126025649UL, HeaderBytes), 4833605);
+        N2CMessageRollForward original = new(2, new CborEncodedValue(HeaderBytes), tip);
+        byte[] bytes = CborSerializer.Serialize(original);
+
+        // Same union, same index 2 — but a tag-24 byte-string payload must resolve to the N2C member.
+        MessageNextResponse decoded = CborSerializer.Deserialize<MessageNextResponse>(bytes);
+
+        N2CMessageRollForward typed = Assert.IsType<N2CMessageRollForward>(decoded);
+        Assert.Equal(
+            Convert.ToHexString(HeaderBytes),
+            Convert.ToHexString(typed.Payload.Value.ToArray()));
+    }
+
+    [Fact]
+    public void IntersectFound_StillResolves_ThroughChainSyncMessage()
+    {
+        // FindIntersection deserializes a ChainSyncMessage and expects MessageIntersectFound (index 5).
+        // With two index-2 RollForward members now in the shared union, the structural probe must not
+        // disturb dispatch of the other indices — this is the regression guard for the bug that broke
+        // FindIntersection when the unions were merged naively.
+        MessageIntersectFound found = new(5, Point.Specific(126025608UL, HeaderBytes), new Tip(Point.Specific(126040000UL, HeaderBytes), 4900000));
+        byte[] bytes = CborSerializer.Serialize(found);
+
+        ChainSyncMessage decoded = CborSerializer.Deserialize<ChainSyncMessage>(bytes);
+
+        _ = Assert.IsType<MessageIntersectFound>(decoded);
+    }
+
+    [Fact]
+    public void FullN2NRollForwardMessage_RoundTrips_AndExposesSlotAndHeader()
+    {
+        // The whole message: [2, [6, #6.24(header)], tip] where tip = [[slot, hash], blockNo].
+        Tip tip = new(Point.Specific(126025649UL, HeaderBytes), 4833605);
+        N2NBlockHeader payload = new(6, new CborEncodedValue(HeaderBytes));
+        N2NMessageRollForward original = new(2, payload, tip);
+
+        byte[] bytes = CborSerializer.Serialize(original);
+        N2NMessageRollForward decoded = CborSerializer.Deserialize<N2NMessageRollForward>(bytes);
+
+        Assert.Equal(2, decoded.Idx);
+        Assert.Equal(6, decoded.Payload.EraTag);
+        Assert.Equal(Convert.ToHexString(HeaderBytes), Convert.ToHexString(decoded.Payload.HeaderCbor.Value.ToArray()));
+        Assert.Equal(126025649UL, ((SpecificPoint)decoded.Tip.Slot).Slot);
+    }
+}

--- a/src/Chrysalis.Network/Cbor/ChainSync/ChainSyncMessage.cs
+++ b/src/Chrysalis.Network/Cbor/ChainSync/ChainSyncMessage.cs
@@ -12,7 +12,10 @@ namespace Chrysalis.Network.Cbor.ChainSync;
 public partial record ChainSyncMessage : CborRecord;
 
 /// <summary>
-/// Intermediate union type for ChainSync responses to a next request (roll-forward, roll-backward, or await-reply).
+/// Intermediate union type for ChainSync responses to a next request (roll-forward, roll-backward,
+/// or await-reply). Await/RollBackward are protocol-agnostic; RollForward has two members sharing
+/// index 2 — <see cref="N2CMessageRollForward"/> (block) and <see cref="N2NMessageRollForward"/>
+/// (header) — which <see cref="ChainSync"/> picks between by its known protocol.
 /// </summary>
 [CborSerializable]
 [CborUnion]
@@ -41,15 +44,19 @@ public partial record MessageAwaitReply(
 ) : MessageNextResponse;
 
 /// <summary>
-/// ChainSync server response carrying a new block or header and the current tip (MsgRollForward).
+/// Node-to-client (N2C) ChainSync server response carrying a new block and the current tip
+/// (MsgRollForward). Shares chain-sync index 2 with the node-to-node
+/// <see cref="N2NMessageRollForward"/> but carries a tag-24 block (<see cref="CborEncodedValue"/>)
+/// rather than an <c>[era, #6.24(header)]</c> header; the serializer's structural probe selects
+/// between them by the payload's CBOR shape.
 /// </summary>
 /// <param name="Idx">The CBOR message index identifier (always 2 for this message type).</param>
-/// <param name="Payload">The CBOR-encoded block or header payload.</param>
+/// <param name="Payload">The tag-24-wrapped block payload.</param>
 /// <param name="Tip">The current tip of the chain as reported by the server.</param>
 [CborSerializable]
 [CborList]
 [CborIndex(2)]
-public partial record MessageRollForward(
+public partial record N2CMessageRollForward(
     [CborOrder(0)] int Idx,
     [CborOrder(1)] CborEncodedValue Payload,
     [CborOrder(2)] Tip Tip

--- a/src/Chrysalis.Network/Cbor/ChainSync/N2NBlockHeader.cs
+++ b/src/Chrysalis.Network/Cbor/ChainSync/N2NBlockHeader.cs
@@ -1,0 +1,34 @@
+using Chrysalis.Codec.Serialization.Attributes;
+using Chrysalis.Codec.Types;
+using Chrysalis.Network.Cbor.Common;
+
+namespace Chrysalis.Network.Cbor.ChainSync;
+
+/// <summary>
+/// The node-to-node (N2N) <c>MsgRollForward</c> payload for Shelley-era-and-later blocks: a CBOR
+/// array <c>[era, #6.24(header)]</c> — the era tag followed by the tag-24-wrapped block header.
+/// </summary>
+/// <param name="EraTag">The era identifier (1 = Shelley, … 6 = Conway).</param>
+/// <param name="HeaderCbor">The tag-24-wrapped block header bytes.</param>
+[CborSerializable]
+[CborList]
+public partial record N2NBlockHeader(
+    [CborOrder(0)] int EraTag,
+    [CborOrder(1)] CborEncodedValue HeaderCbor
+) : CborRecord;
+
+/// <summary>
+/// Node-to-node (N2N) <c>MsgRollForward</c> — chain-sync index 2, carrying an
+/// <c>[era, #6.24(header)]</c> header (<see cref="N2NBlockHeader"/>). It is the only chain-sync
+/// next-response that differs from node-to-client; Await/RollBackward are shared. <see cref="ChainSync"/>
+/// knows its protocol, so it deserializes this type directly for N2N connections (and
+/// <see cref="N2CMessageRollForward"/> for N2C) — no payload-shape probe on the hot path.
+/// </summary>
+[CborSerializable]
+[CborList]
+[CborIndex(2)]
+public partial record N2NMessageRollForward(
+    [CborOrder(0)] int Idx,
+    [CborOrder(1)] N2NBlockHeader Payload,
+    [CborOrder(2)] Tip Tip
+) : MessageNextResponse;

--- a/src/Chrysalis.Network/Cbor/Handshake/VersionTable.cs
+++ b/src/Chrysalis.Network/Cbor/Handshake/VersionTable.cs
@@ -46,13 +46,20 @@ public static class VersionTables
     /// <summary>
     /// Creates a node-to-node version table proposing versions 11 through 14.
     /// </summary>
+    /// <remarks>
+    /// Declares <c>InitiatorOnlyDiffusionMode = true</c>: this client only initiates the
+    /// chain-sync/block-fetch/keep-alive mini-protocols and does not service responder duties.
+    /// A P2P node (e.g. cardano-node 11+) that negotiates InitiatorAndResponder would promote
+    /// the connection to a hot peer and initiate protocols back toward us, stalling the
+    /// multiplexer. Keep this <c>true</c> unless responder-side protocols are implemented.
+    /// </remarks>
     /// <param name="networkMagic">The network magic number (default is 2 for preview testnet).</param>
     /// <returns>A new <see cref="N2NVersionTable"/> with versions V11 through V14.</returns>
     public static N2NVersionTable N2nV11AndAbove(ulong networkMagic = 2) => new(new()
         {
-            {N2NVersions.V11, new N2NVersionData(networkMagic, false, 0, false)},
-            {N2NVersions.V12, new N2NVersionData(networkMagic, false, 0, false)},
-            {N2NVersions.V13, new N2NVersionData(networkMagic, false, 0, false)},
-            {N2NVersions.V14, new N2NVersionData(networkMagic, false, 0, false)},
+            {N2NVersions.V11, new N2NVersionData(networkMagic, true, 0, false)},
+            {N2NVersions.V12, new N2NVersionData(networkMagic, true, 0, false)},
+            {N2NVersions.V13, new N2NVersionData(networkMagic, true, 0, false)},
+            {N2NVersions.V14, new N2NVersionData(networkMagic, true, 0, false)},
         });
 }

--- a/src/Chrysalis.Network/MiniProtocols/ChainSync.cs
+++ b/src/Chrysalis.Network/MiniProtocols/ChainSync.cs
@@ -126,11 +126,11 @@ public class ChainSync : IMiniProtocol
                 // Fast-path: write pre-encoded segment directly to bearer
                 await _buffer.SendPreEncodedSegmentAsync(_preEncodedNextRequest, cancellationToken).ConfigureAwait(false);
                 State = ChainSyncState.CanAwait;
-                response = await _buffer.ReceiveFullMessageAsync<MessageNextResponse>(cancellationToken).ConfigureAwait(false);
+                response = await ReceiveNextResponseAsync(cancellationToken).ConfigureAwait(false);
                 break;
 
             case ChainSyncState.MustReply:
-                response = await _buffer.ReceiveFullMessageAsync<MessageNextResponse>(cancellationToken).ConfigureAwait(false);
+                response = await ReceiveNextResponseAsync(cancellationToken).ConfigureAwait(false);
                 break;
             case ChainSyncState.CanAwait:
                 break;
@@ -142,15 +142,14 @@ public class ChainSync : IMiniProtocol
                 throw new InvalidOperationException($"Cannot request next in state {State}");
         }
 
-        // Update state based on response
+        // Update state based on response. N2C and N2N RollForward follow the same agency rules.
         switch (response)
         {
             case MessageAwaitReply:
                 State = ChainSyncState.MustReply;
                 break;
-            case MessageRollForward:
-                State = ChainSyncState.Idle;
-                break;
+            case N2CMessageRollForward:
+            case N2NMessageRollForward:
             case MessageRollBackward:
                 State = ChainSyncState.Idle;
                 break;
@@ -174,8 +173,10 @@ public class ChainSync : IMiniProtocol
     public async Task SendNextRequestBatchAsync(int count, CancellationToken cancellationToken) => await _buffer.SendPreEncodedSegmentBatchAsync(_preEncodedNextRequest, count, cancellationToken).ConfigureAwait(false);
 
     /// <summary>
-    /// Receives the next response from the server without sending a request.
-    /// For use in pipelined sync where requests were sent separately.
+    /// Receives the next chain-sync response. A single <see cref="MessageNextResponse"/> union serves
+    /// both N2C and N2N: its two index-2 RollForward members (<see cref="N2CMessageRollForward"/> and
+    /// <see cref="N2NMessageRollForward"/>) are resolved by the serializer's structural probe on the
+    /// payload shape. Deserialization reports the exact consumed length, keeping the buffer in sync.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public async Task<MessageNextResponse> ReceiveNextResponseAsync(CancellationToken cancellationToken) => await _buffer.ReceiveFullMessageAsync<MessageNextResponse>(cancellationToken).ConfigureAwait(false);

--- a/src/Chrysalis.Network/Multiplexer/ChannelBuffer.cs
+++ b/src/Chrysalis.Network/Multiplexer/ChannelBuffer.cs
@@ -12,6 +12,12 @@ namespace Chrysalis.Network.Multiplexer;
 /// Uses a Pallas-style accumulation buffer: segment payloads are appended to a temp buffer,
 /// CBOR decode is attempted after each append, and consumed bytes are drained on success.
 /// Single-segment messages are deserialized directly from the received array (zero extra copy).
+/// <para>
+/// INVARIANT: a returned message may be a zero-copy view into the internal buffer (e.g. a
+/// <c>CborEncodedValue</c> body the caller reads lazily). The buffer must therefore never be moved
+/// in place while a result is outstanding. Callers consume each message before the next receive,
+/// so any in-place reclamation (<see cref="Compact"/>) is only safe at the start of the next receive.
+/// </para>
 /// </remarks>
 public sealed class ChannelBuffer(AgentChannel channel)
 {
@@ -66,7 +72,7 @@ public sealed class ChannelBuffer(AgentChannel channel)
             if (TryDeserialize(out T? result, out int consumed))
             {
                 _tempOffset += consumed;
-                CompactIfNeeded();
+                ResetIfDrained();
                 return result!;
             }
         }
@@ -104,7 +110,7 @@ public sealed class ChannelBuffer(AgentChannel channel)
             if (TryDeserialize(out T? result, out int consumed))
             {
                 _tempOffset += consumed;
-                CompactIfNeeded();
+                ResetIfDrained();
                 return result!;
             }
 
@@ -177,20 +183,21 @@ public sealed class ChannelBuffer(AgentChannel channel)
     }
 
     /// <summary>
-    /// Compacts the buffer by moving data to the front if offset is too large.
+    /// Resets the read window to the front of the buffer once it is fully drained. Deliberately does
+    /// NOT move data in place — that would corrupt an outstanding zero-copy result (see the class
+    /// invariant). Reclamation of leftover bytes happens at the start of the next receive instead.
     /// </summary>
-    private void CompactIfNeeded()
+    private void ResetIfDrained()
     {
-        // Compact when offset exceeds half the buffer or all data consumed
+        // In-place compaction here was a bug: a just-returned message can still be a view into _temp
+        // (e.g. a CborEncodedValue body the caller reads lazily), so moving _temp would shift those
+        // bytes out from under it — flaky "Expected major type Array" when BlockFetch streamed many
+        // large blocks. Only the offset reset (no data move) is safe at this point.
         int usedLength = _tempLength - _tempOffset;
         if (usedLength == 0)
         {
             _tempOffset = 0;
             _tempLength = 0;
-        }
-        else if (_tempOffset > _temp.Length / 2)
-        {
-            Compact();
         }
     }
 


### PR DESCRIPTION
## What

Adds node-to-node (N2N) chain-sync support and unifies N2C/N2N RollForward behind one `MessageNextResponse` union.

### Features
- **N2N chain-sync**: new `N2NBlockHeader` (`[era, #6.24(header)]`) and `N2NMessageRollForward`. Both share chain-sync index 2 with the N2C RollForward inside one `MessageNextResponse`; the serializer's structural probe selects between them by payload shape (tag-24 block vs. array header).
- **Generalized union dispatch** (`Chrysalis.Codec.CodeGen`): when union members collide on a leading index, the generator recurses to a secondary structural probe on the first distinguishing field instead of falling back to a whole-union try/catch. Backward-compatible — non-colliding unions emit byte-identical code.
- **Diffusion mode**: `InitiatorOnlyDiffusionMode = true` so a node-11 P2P stack serves us instead of promoting us to a hot peer and stalling.

### Fix
- **`ChannelBuffer`**: in-place compaction was moving the reusable buffer out from under a just-returned zero-copy result — flaky `Expected major type Array` failures when BlockFetch streamed several large blocks. Compaction now happens only at the start of the next receive.

### Breaking
- ⚠️ **`MessageRollForward` → `N2CMessageRollForward`**. Shares index 2 with `N2NMessageRollForward`, so no compatibility alias is possible. Consumers pattern-matching the N2C RollForward must update.

### Tests
Generator `SecondaryProbeUnionTests`, network `N2NRollForwardCborTests`; full suite green (1,302 non-integration tests). N2N validated live against preprod (chain-sync + BlockFetch + balance/rollback).