### PR TITLE
fix(network): parse Byron N2N RollForward headers and surface decode errors

### DIFF
--- a/src/Chrysalis.Codec/Extensions/Cardano/Core/BlockExtensions.cs
+++ b/src/Chrysalis.Codec/Extensions/Cardano/Core/BlockExtensions.cs
@@ -23,8 +23,8 @@ public static class BlockExtensions
         ArgumentNullException.ThrowIfNull(self);
         return self switch
         {
-            ByronMainBlock byron => (byron.Header.ConsensusData.SlotId.Epoch * 21600) + byron.Header.ConsensusData.SlotId.Slot,
-            ByronEbBlock ebb => ebb.Header.ConsensusData.Epoch * 21600,
+            ByronMainBlock byron => byron.Header.ConsensusData.ToAbsoluteSlot(),
+            ByronEbBlock ebb => ebb.Header.ConsensusData.ToAbsoluteSlot(),
             _ => self.Header().HeaderBody.Slot()
         };
     }
@@ -141,6 +141,22 @@ public static class BlockExtensions
         headerCbor.CopyTo(wrapped.AsSpan(2));
         return Blake2Fast.Blake2b.HashData(32, wrapped);
     }
+
+    /// <summary>The number of slots per epoch in the Byron era (fixed at 21600).</summary>
+    public const ulong ByronSlotsPerEpoch = 21600;
+
+    /// <summary>
+    /// Converts a Byron main-block consensus slot id to an absolute slot:
+    /// <c>epoch * <see cref="ByronSlotsPerEpoch"/> + intra-epoch slot</c>.
+    /// </summary>
+    public static ulong ToAbsoluteSlot(this ByronBlockCons consensus) =>
+        (consensus.SlotId.Epoch * ByronSlotsPerEpoch) + consensus.SlotId.Slot;
+
+    /// <summary>
+    /// Converts a Byron epoch-boundary block (EBB) consensus to an absolute slot:
+    /// <c>epoch * <see cref="ByronSlotsPerEpoch"/></c> (an EBB sits at the first slot of its epoch).
+    /// </summary>
+    public static ulong ToAbsoluteSlot(this ByronEbbCons consensus) => consensus.Epoch * ByronSlotsPerEpoch;
 
     /// <summary>
     /// Gets the transaction bodies from the block.

--- a/src/Chrysalis.Network.Cli/Program.cs
+++ b/src/Chrysalis.Network.Cli/Program.cs
@@ -222,7 +222,7 @@ internal static class Program
                         }
                         else
                         {
-                            Console.WriteLine($"  WARN: skipped unparseable header (payload {rollForward.Payload.HeaderCbor.Value.Length} bytes)");
+                            Console.WriteLine($"  WARN: skipped unparseable header (payload {rollForward.Payload.Raw.Length} bytes)");
                         }
                         break;
                     case MessageRollBackward rollBackward:
@@ -508,8 +508,8 @@ internal static class Program
         point = null;
         try
         {
-            // N2N RollForward payload is the typed [era, #6.24(header)]; decode the header for its point.
-            ChainSyncHeader header = new((byte)rollForward.Payload.EraTag, null, rollForward.Payload.HeaderCbor.Value);
+            // N2N RollForward payload is [era, header]; decode era-aware (Byron through Conway) for its point.
+            ChainSyncHeader header = ChainSyncHeader.Decode(rollForward.Payload.Raw);
             ChainPoint cp = header.ExtractPoint();
             point = Point.Specific(cp.Slot, cp.Hash);
         }

--- a/src/Chrysalis.Network.Tests/N2NRollForwardCborTests.cs
+++ b/src/Chrysalis.Network.Tests/N2NRollForwardCborTests.cs
@@ -11,51 +11,83 @@ namespace Chrysalis.Network.Tests;
 /// just bytes. N2C and N2N RollForward share chain-sync index 2 inside a single
 /// <see cref="MessageNextResponse"/> union; the serializer's structural probe resolves them by the
 /// payload's CBOR shape: a tag-24 block (<see cref="N2CMessageRollForward"/>) vs. an
-/// <c>[era, #6.24(header)]</c> array (<see cref="N2NMessageRollForward"/>).
+/// <c>[era, header]</c> array (<see cref="N2NMessageRollForward"/>). The N2N header is era-shaped —
+/// Shelley-and-later carry the tag-24 header directly, Byron nests it inside a bare array — so these
+/// also guard that <em>both</em> shapes deserialize without throwing and round-trip via their raw bytes.
 /// </summary>
 public class N2NRollForwardCborTests
 {
-    // A 32-byte stand-in for header/block content (real payloads are larger; shape is what matters).
+    // A 32-byte stand-in for header content (real headers are larger; shape is what matters).
     private static readonly byte[] HeaderBytes =
         Convert.FromHexString("7EF942E6A670AF6310737E9230B22E11A4BB1AF69BED9AFFB09B1025B371D1CD");
 
-    // The N2N payload: 82 (array2) 06 (era=6 Conway) D818 (tag24) 5820 (bstr len 32) <32 bytes>.
-    private static byte[] BuildN2nPayload() =>
+    // Shelley+ N2N payload: 82 (array2) 06 (era=6 Conway) D818 (tag24) 5820 (bstr32) <32 bytes>.
+    private static byte[] BuildShelleyPayload() =>
         [0x82, 0x06, 0xD8, 0x18, 0x58, 0x20, .. HeaderBytes];
 
+    // Byron N2N payload: 82 (array2) 00 (era=0) 82 (array2) [82 00 18 20] (=[subTag 0, size 32])
+    //                    D818 (tag24) 5820 (bstr32) <32 bytes>. The tag-24 header is nested one
+    //                    level deeper than Shelley+ — the exact shape that broke the old decoder.
+    private static byte[] BuildByronPayload() =>
+        [0x82, 0x00, 0x82, 0x82, 0x00, 0x18, 0x20, 0xD8, 0x18, 0x58, 0x20, .. HeaderBytes];
+
+    // Tip = [[slot, hash32], blockNo]: 82 [82 1A <slot=126025649> 5820 <32>] 1A <blockNo>.
+    private static byte[] BuildTip() =>
+        [0x82, 0x82, 0x1A, 0x07, 0x82, 0xFF, 0xB1, 0x58, 0x20, .. HeaderBytes, 0x1A, 0x00, 0x49, 0xC0, 0x85];
+
+    // Full RollForward message: 83 (array3) 02 (idx) <payload> <tip>.
+    private static byte[] BuildRollForward(byte[] payload) =>
+        [0x83, 0x02, .. payload, .. BuildTip()];
+
     [Fact]
-    public void N2NBlockHeader_DeserializesCleanly_AsArrayEraPlusEncodedHeader()
+    public void N2NBlockHeader_ShelleyPayload_DeserializesAndRoundTrips()
     {
-        byte[] payload = BuildN2nPayload();
+        byte[] payload = BuildShelleyPayload();
 
         N2NBlockHeader decoded = CborSerializer.Deserialize<N2NBlockHeader>(payload);
 
         Assert.Equal(6, decoded.EraTag);
-        Assert.Equal(
-            Convert.ToHexString(HeaderBytes),
-            Convert.ToHexString(decoded.HeaderCbor.Value.ToArray()));
+        // The lazy union reader captures the full [era, header] bytes; re-serialization is byte-exact.
+        Assert.Equal(Convert.ToHexString(payload), Convert.ToHexString(decoded.Raw.ToArray()));
+        Assert.Equal(Convert.ToHexString(payload), Convert.ToHexString(CborSerializer.Serialize(decoded)));
     }
 
     [Fact]
-    public void SharedUnion_ResolvesN2NRollForward_ByArrayPayload()
+    public void N2NBlockHeader_ByronPayload_DeserializesWithoutThrowing()
     {
-        Tip tip = new(Point.Specific(126025649UL, HeaderBytes), 4833605);
-        N2NMessageRollForward original = new(2, new N2NBlockHeader(6, new CborEncodedValue(HeaderBytes)), tip);
-        byte[] bytes = CborSerializer.Serialize(original);
+        // The regression guard for the infinite-hang bug: the Byron header is a bare array, not a
+        // tag-24 byte string, so the old CborEncodedValue-typed field threw "Expected major type
+        // ByteString". The era-discriminated union must now parse it cleanly and preserve its bytes.
+        byte[] payload = BuildByronPayload();
 
-        // Deserialize against the SHARED union — the structural probe must pick the N2N (array) member.
-        MessageNextResponse decoded = CborSerializer.Deserialize<MessageNextResponse>(bytes);
+        N2NBlockHeader decoded = CborSerializer.Deserialize<N2NBlockHeader>(payload);
 
-        N2NMessageRollForward typed = Assert.IsType<N2NMessageRollForward>(decoded);
-        Assert.Equal(6, typed.Payload.EraTag);
-        Assert.Equal(126025649UL, ((SpecificPoint)typed.Tip.Slot).Slot);
+        Assert.Equal(0, decoded.EraTag);
+        Assert.Equal(Convert.ToHexString(payload), Convert.ToHexString(decoded.Raw.ToArray()));
+    }
+
+    [Fact]
+    public void SharedUnion_ResolvesN2NRollForward_ByArrayPayload_BothEras()
+    {
+        foreach (byte[] payload in new[] { BuildShelleyPayload(), BuildByronPayload() })
+        {
+            byte[] bytes = BuildRollForward(payload);
+
+            // Deserialize against the SHARED union — the structural probe must pick the N2N (array) member.
+            MessageNextResponse decoded = CborSerializer.Deserialize<MessageNextResponse>(bytes);
+
+            N2NMessageRollForward typed = Assert.IsType<N2NMessageRollForward>(decoded);
+            Assert.Equal(2, typed.Idx);
+            // The payload's raw bytes route through the era-aware decoder for the chain point.
+            Assert.Equal(Convert.ToHexString(payload), Convert.ToHexString(typed.Payload.Raw.ToArray()));
+            Assert.Equal(126025649UL, ((SpecificPoint)typed.Tip.Slot).Slot);
+        }
     }
 
     [Fact]
     public void SharedUnion_ResolvesN2CRollForward_ByTag24Payload()
     {
-        Tip tip = new(Point.Specific(126025649UL, HeaderBytes), 4833605);
-        N2CMessageRollForward original = new(2, new CborEncodedValue(HeaderBytes), tip);
+        N2CMessageRollForward original = new(2, new CborEncodedValue(HeaderBytes), new Tip(Point.Specific(126025649UL, HeaderBytes), 4833605));
         byte[] bytes = CborSerializer.Serialize(original);
 
         // Same union, same index 2 — but a tag-24 byte-string payload must resolve to the N2C member.
@@ -83,19 +115,16 @@ public class N2NRollForwardCborTests
     }
 
     [Fact]
-    public void FullN2NRollForwardMessage_RoundTrips_AndExposesSlotAndHeader()
+    public void FullN2NRollForwardMessage_RoundTrips_AndExposesEraAndSlot()
     {
         // The whole message: [2, [6, #6.24(header)], tip] where tip = [[slot, hash], blockNo].
-        Tip tip = new(Point.Specific(126025649UL, HeaderBytes), 4833605);
-        N2NBlockHeader payload = new(6, new CborEncodedValue(HeaderBytes));
-        N2NMessageRollForward original = new(2, payload, tip);
+        byte[] bytes = BuildRollForward(BuildShelleyPayload());
 
-        byte[] bytes = CborSerializer.Serialize(original);
         N2NMessageRollForward decoded = CborSerializer.Deserialize<N2NMessageRollForward>(bytes);
 
         Assert.Equal(2, decoded.Idx);
         Assert.Equal(6, decoded.Payload.EraTag);
-        Assert.Equal(Convert.ToHexString(HeaderBytes), Convert.ToHexString(decoded.Payload.HeaderCbor.Value.ToArray()));
         Assert.Equal(126025649UL, ((SpecificPoint)decoded.Tip.Slot).Slot);
+        Assert.Equal(Convert.ToHexString(bytes), Convert.ToHexString(CborSerializer.Serialize(decoded)));
     }
 }

--- a/src/Chrysalis.Network/Cbor/ChainSync/ChainSyncHeader.cs
+++ b/src/Chrysalis.Network/Cbor/ChainSync/ChainSyncHeader.cs
@@ -75,14 +75,14 @@ public record ChainSyncHeader(
             if (IsByronEbb)
             {
                 ByronEbbHead ebbHead = CborSerializer.Deserialize<ByronEbbHead>(HeaderCbor);
-                ulong slot = ebbHead.ConsensusData.Epoch * 21600;
+                ulong slot = ebbHead.ConsensusData.ToAbsoluteSlot();
                 byte[] hash = BlockExtensions.HashByronHeader(0, HeaderCbor.Span);
                 return new ChainPoint(slot, hash, 0);
             }
             else
             {
                 ByronBlockHead blockHead = CborSerializer.Deserialize<ByronBlockHead>(HeaderCbor);
-                ulong slot = (blockHead.ConsensusData.SlotId.Epoch * 21600) + blockHead.ConsensusData.SlotId.Slot;
+                ulong slot = blockHead.ConsensusData.ToAbsoluteSlot();
                 byte[] hash = BlockExtensions.HashByronHeader(1, HeaderCbor.Span);
                 ulong height = blockHead.ConsensusData.Difficulty.GetValue().FirstOrDefault();
                 return new ChainPoint(slot, hash, height);

--- a/src/Chrysalis.Network/Cbor/ChainSync/N2NBlockHeader.cs
+++ b/src/Chrysalis.Network/Cbor/ChainSync/N2NBlockHeader.cs
@@ -1,3 +1,4 @@
+using Chrysalis.Codec.Serialization;
 using Chrysalis.Codec.Serialization.Attributes;
 using Chrysalis.Codec.Types;
 using Chrysalis.Network.Cbor.Common;
@@ -5,24 +6,92 @@ using Chrysalis.Network.Cbor.Common;
 namespace Chrysalis.Network.Cbor.ChainSync;
 
 /// <summary>
-/// The node-to-node (N2N) <c>MsgRollForward</c> payload for Shelley-era-and-later blocks: a CBOR
-/// array <c>[era, #6.24(header)]</c> — the era tag followed by the tag-24-wrapped block header.
+/// The node-to-node (N2N) <c>MsgRollForward</c> payload: a CBOR array <c>[era, header]</c>. The header
+/// shape is era-dependent — Byron (era 0) nests its tag-24 header one level deeper inside a bare array
+/// (<c>[[subTag, size], #6.24(header)]</c>), whereas Shelley-and-later (era ≥ 1) carry the tag-24 header
+/// directly (<c>#6.24(header)</c>). This is an era-discriminated union (mirroring
+/// <see cref="Codec.Types.Cardano.Core.BlockWithEra"/>) so RollForward of <em>any</em> era deserializes
+/// without throwing: the lazy reader only records field boundaries, leaving <see cref="ICborType.Raw"/>
+/// populated with the full <c>[era, header]</c> bytes. Consumers extract the chain point by routing
+/// <see cref="ICborType.Raw"/> through <see cref="ChainSyncHeader.Decode"/>.
 /// </summary>
-/// <param name="EraTag">The era identifier (1 = Shelley, … 6 = Conway).</param>
-/// <param name="HeaderCbor">The tag-24-wrapped block header bytes.</param>
 [CborSerializable]
 [CborList]
-public partial record N2NBlockHeader(
-    [CborOrder(0)] int EraTag,
-    [CborOrder(1)] CborEncodedValue HeaderCbor
-) : CborRecord;
+public readonly partial record struct N2NBlockHeader : ICborType
+{
+    /// <summary>The era identifier (0 = Byron, 1 = Shelley, … 6 = Conway).</summary>
+    [CborOrder(0)] public partial int EraTag { get; }
+
+    /// <summary>
+    /// The era-shaped header element: the nested Byron container (<see cref="ByronN2NHeader"/>) for era 0,
+    /// or the tag-24-wrapped header (<see cref="ShelleyN2NHeader"/>) for Shelley-and-later. Materialization
+    /// is era-dispatched, but the wire bytes are always available via <see cref="ICborType.Raw"/>.
+    /// </summary>
+    [CborOrder(1)]
+    [CborUnionHint(nameof(EraTag), 0, typeof(ByronN2NHeader))]
+    [CborUnionHint(nameof(EraTag), 1, typeof(ShelleyN2NHeader))]
+    [CborUnionHint(nameof(EraTag), 2, typeof(ShelleyN2NHeader))]
+    [CborUnionHint(nameof(EraTag), 3, typeof(ShelleyN2NHeader))]
+    [CborUnionHint(nameof(EraTag), 4, typeof(ShelleyN2NHeader))]
+    [CborUnionHint(nameof(EraTag), 5, typeof(ShelleyN2NHeader))]
+    [CborUnionHint(nameof(EraTag), 6, typeof(ShelleyN2NHeader))]
+    public partial INetworkBlockHeader Header { get; }
+}
 
 /// <summary>
-/// Node-to-node (N2N) <c>MsgRollForward</c> — chain-sync index 2, carrying an
-/// <c>[era, #6.24(header)]</c> header (<see cref="N2NBlockHeader"/>). It is the only chain-sync
-/// next-response that differs from node-to-client; Await/RollBackward are shared. <see cref="ChainSync"/>
-/// knows its protocol, so it deserializes this type directly for N2N connections (and
-/// <see cref="N2CMessageRollForward"/> for N2C) — no payload-shape probe on the hot path.
+/// Era-shaped N2N header element, discriminated by the leading era tag of <see cref="N2NBlockHeader"/>:
+/// <see cref="ByronN2NHeader"/> for era 0, <see cref="ShelleyN2NHeader"/> for Shelley-and-later.
+/// </summary>
+[CborSerializable]
+[CborUnion]
+public partial interface INetworkBlockHeader : ICborType;
+
+/// <summary>
+/// The Byron (era 0) N2N header body: <c>[[subTag, size], #6.24(header)]</c> — a two-element prefix
+/// followed by the tag-24-wrapped header. It exists so the era-0 branch parses without throwing; the
+/// header bytes themselves are read era-aware by <see cref="ChainSyncHeader.Decode"/>.
+/// </summary>
+[CborSerializable]
+[CborList]
+public partial record ByronN2NHeader(
+    [CborOrder(0)] CborDefList<ulong> Prefix,
+    [CborOrder(1)] CborEncodedValue Header
+) : INetworkBlockHeader
+{
+    /// <inheritdoc />
+    public ReadOnlyMemory<byte> Raw { get; set; }
+
+    /// <inheritdoc />
+    public int ConstrIndex { get; set; }
+
+    /// <inheritdoc />
+    public bool IsIndefinite { get; set; }
+}
+
+/// <summary>
+/// The Shelley-and-later (era ≥ 1) N2N header: the tag-24-wrapped block header (<c>#6.24(header)</c>).
+/// </summary>
+[CborSerializable]
+public partial record ShelleyN2NHeader(
+    CborEncodedValue Header
+) : INetworkBlockHeader
+{
+    /// <inheritdoc />
+    public ReadOnlyMemory<byte> Raw { get; set; }
+
+    /// <inheritdoc />
+    public int ConstrIndex { get; set; }
+
+    /// <inheritdoc />
+    public bool IsIndefinite { get; set; }
+}
+
+/// <summary>
+/// Node-to-node (N2N) <c>MsgRollForward</c> — chain-sync index 2, carrying an <c>[era, header]</c>
+/// payload (<see cref="N2NBlockHeader"/>). It is the only chain-sync next-response that differs from
+/// node-to-client; Await/RollBackward are shared. The <see cref="MessageNextResponse"/> structural
+/// probe routes index-2 RollForwards by payload shape: an array selects this N2N member (both Byron
+/// and Shelley N2N payloads are arrays), a tag-24 byte string selects <see cref="N2CMessageRollForward"/>.
 /// </summary>
 [CborSerializable]
 [CborList]

--- a/src/Chrysalis.Network/Multiplexer/ChannelBuffer.cs
+++ b/src/Chrysalis.Network/Multiplexer/ChannelBuffer.cs
@@ -2,6 +2,8 @@ using System.Buffers;
 using Chrysalis.Codec.Serialization;
 using Chrysalis.Codec.Types;
 using Chrysalis.Network.Core;
+using SAIB.Cbor;
+using SAIB.Cbor.Serialization;
 
 namespace Chrysalis.Network.Multiplexer;
 
@@ -137,7 +139,37 @@ public sealed class ChannelBuffer(AgentChannel channel)
             result = CborSerializer.Deserialize<T>(data, out consumed);
             return true;
         }
-        catch (Exception)
+        catch (Exception) when (!IsCompleteFrame(data.Span))
+        {
+            // A whole CBOR frame is not yet buffered — the decode failed only because bytes are
+            // still in flight. Swallow and keep reading. A decode failure on a frame that IS fully
+            // present (e.g. an unsupported shape) is NOT swallowed: it propagates so a structural gap
+            // surfaces loudly instead of stalling the receive loop forever waiting for more bytes.
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Reports whether <paramref name="data"/> begins with at least one complete CBOR data item.
+    /// Used to tell a genuinely incomplete frame (buffer underrun — keep reading) apart from a
+    /// complete-but-undecodable frame (surface the error). <see cref="CborReader.SkipDataItem"/>
+    /// throws only when it runs off the end of the buffer mid-item, so a clean skip means the frame
+    /// is fully present.
+    /// </summary>
+    private static bool IsCompleteFrame(ReadOnlySpan<byte> data)
+    {
+        if (data.IsEmpty)
+        {
+            return false;
+        }
+
+        try
+        {
+            CborReader reader = new(data);
+            reader.SkipDataItem();
+            return true;
+        }
+        catch (CborException)
         {
             return false;
         }
@@ -229,14 +261,16 @@ public sealed class ChannelBuffer(AgentChannel channel)
             return false;
         }
 
+        ReadOnlyMemory<byte> data = new(_temp, _tempOffset, usedLength);
         try
         {
-            ReadOnlyMemory<byte> data = new(_temp, _tempOffset, usedLength);
             result = CborSerializer.Deserialize<T>(data, out consumed);
             return true;
         }
-        catch (Exception)
+        catch (Exception) when (!IsCompleteFrame(data.Span))
         {
+            // See TryDeserializeDirect: only swallow when the frame is still partial. A failure on a
+            // fully-buffered frame propagates rather than looping forever on more reads.
             return false;
         }
     }


### PR DESCRIPTION
## Summary
Fixes an infinite hang when syncing **N2N from chain origin** — Chrysalis could not parse the **Byron (era 0)** RollForward header, and the receive loop masked the decode failure as an incomplete frame so it never surfaced.

## Root cause
The Byron N2N header nests its tag-24 one level deeper than Shelley+:
- Shelley → Conway: `[era, #6.24(header)]`
- Byron: `[era, [[subTag, size], #6.24(header)]]`

The generated `N2NBlockHeader` hard-typed the header as `CborEncodedValue` (tag-24 only) → threw on Byron's array → `ChannelBuffer.ReceiveFullMessageAsync`'s catch-all treated it as "incomplete, read more" → hang. Era-complete header decoding already existed in `ChainSyncHeader.Decode` (#335); #377 introduced a parallel Shelley-only path and pointed consumers at it. No test ever started from Byron, so it slipped through.

## Changes
- **`N2NBlockHeader`** → era-discriminated union (`CborUnionHint`, mirrors `BlockWithEra`): parses any era without throwing, exposes `.Raw`, and routes extraction back through the single era-complete `ChainSyncHeader.Decode`.
- **`ChannelBuffer`** → no longer masks a decode error on a *complete* frame as "incomplete" (a `SkipDataItem` probe tells a genuine underrun from a malformed frame); the hang becomes a surfaced error.
- **`BlockExtensions`** → consolidate the duplicated Byron slot formula (`epoch * 21600 + slot`) into `ByronSlotsPerEpoch` + `ToAbsoluteSlot()`.
- CLI consumer + N2N unit tests updated (Byron **and** Shelley regression).

## Testing
- Full non-integration suite (the release gate): **1,303 passed, 0 failed**.
- Live (preprod, cardano-node 11): Byron headers stream from origin, 0 exceptions; **full origin→tip N2N sync = 4,843,043 blocks, all eras Byron→Conway, 0 failures**; full origin→tip N2C = 4.84M blocks, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
