### PR TITLE
fix(tx): sort multi-withdrawal redeemer pointers + inline witness scripts

### DIFF
--- a/src/Chrysalis.Tx/Builders/TransactionTemplateBuilder.cs
+++ b/src/Chrysalis.Tx/Builders/TransactionTemplateBuilder.cs
@@ -468,7 +468,7 @@ public sealed class TransactionTemplateBuilder<T>
                 }
             }
 
-            BuildRedeemers(context, param, inputIdToIndex, refInputIdToOrderedIndex, outputMappings);
+            BuildRedeemers(context, param, parties, inputIdToIndex, refInputIdToOrderedIndex, outputMappings);
 
             if (context.Redeemers.Count > 0)
             {
@@ -859,6 +859,7 @@ public sealed class TransactionTemplateBuilder<T>
     private void BuildRedeemers(
         BuildContext buildContext,
         T param,
+        Dictionary<string, string> parties,
         Dictionary<string, ulong> inputIdToIndex,
         Dictionary<string, ulong> refInputIdToIndex,
         Dictionary<string, Dictionary<string, ulong>> outputMappings)
@@ -911,6 +912,35 @@ public sealed class TransactionTemplateBuilder<T>
             }
         }
 
+        // Withdrawal redeemer pointers are keyed by the reward account's index in
+        // the ledger's *sorted* withdrawal map (the same order FindScript and the
+        // Plutus script context use), NOT the order withdrawals were added to the
+        // template. With a single withdrawal these coincide; with two or more they
+        // diverge, and an insertion-ordered pointer feeds the wrong redeemer to a
+        // script. Resolve each withdrawal's reward account and rank them.
+        Dictionary<int, ulong> withdrawalSortedIndex = [];
+        {
+            List<(int Insertion, byte[] Account)> accounts = [];
+            int wi = 0;
+            foreach (WithdrawalConfig<T> config in _withdrawalConfigs)
+            {
+                WithdrawalOptions<T> probe = new() { From = "", Amount = 0 };
+                config(probe, param);
+                byte[] account = probe.From.Length != 0 && parties.TryGetValue(probe.From, out string? bech)
+                    ? WalletAddress.FromBech32(bech).ToBytes()
+                    : [];
+                accounts.Add((wi, account));
+                wi++;
+            }
+
+            int rank = 0;
+            foreach ((int insertion, byte[] _) in accounts.OrderBy(a => (ReadOnlyMemory<byte>)a.Account, RewardAccountComparer.Instance))
+            {
+                withdrawalSortedIndex[insertion] = (ulong)rank;
+                rank++;
+            }
+        }
+
         int withdrawalIndex = 0;
         foreach (WithdrawalConfig<T> config in _withdrawalConfigs)
         {
@@ -931,7 +961,7 @@ public sealed class TransactionTemplateBuilder<T>
 
                 if (redeemerObj != null)
                 {
-                    ProcessRedeemer(buildContext, redeemerObj, (ulong)withdrawalIndex);
+                    ProcessRedeemer(buildContext, redeemerObj, withdrawalSortedIndex[withdrawalIndex]);
                 }
             }
 
@@ -1174,6 +1204,11 @@ public sealed class TransactionTemplateBuilder<T>
             {
                 WalletAddress withdrawalAddress = WalletAddress.FromBech32(parties[withdrawalOptions.From]);
                 rewards.Add(new RewardAccount(withdrawalAddress.ToBytes()), withdrawalOptions.Amount);
+            }
+            // Inline witness script (no reference input) — embed it in the witness set.
+            if (withdrawalOptions.Script is not null)
+            {
+                _ = context.TxBuilder.AddPlutusScript(withdrawalOptions.Script);
             }
             if (withdrawalOptions.RedeemerBuilder is not null || withdrawalOptions.Redeemer is not null)
             {

--- a/src/Chrysalis.Tx/Models/Options.cs
+++ b/src/Chrysalis.Tx/Models/Options.cs
@@ -251,6 +251,15 @@ public record WithdrawalOptions<T>
     /// <summary>Gets or sets the identifier for this withdrawal.</summary>
     public string? Id { get; set; }
 
+    /// <summary>
+    /// Gets or sets an inline witness script for this withdrawal. When set, the
+    /// script is embedded in the transaction's witness set instead of being
+    /// supplied via a reference input — useful when a reference input would
+    /// perturb ordering that a co-spent script depends on (e.g. a DEX that reads
+    /// its settings as the first reference input).
+    /// </summary>
+    public IScript? Script { get; set; }
+
     /// <summary>Gets or sets the redeemer map for script validation.</summary>
     public RedeemerMap? Redeemer { get; set; }
 


### PR DESCRIPTION
## Summary

Two fixes to `TransactionTemplateBuilder`'s withdrawal handling, both exercised by multi-withdrawal Plutus V3 transactions.

### 1. Multi-withdrawal redeemer pointers were insertion-ordered, not sorted

`BuildRedeemers` keyed each withdrawal redeemer pointer `(tag=3, index)` by the order `AddWithdrawal` was called. But the ledger — and Chrysalis's own `FindScript` / script-context resolution — index withdrawal scripts by the reward account's position in the **sorted** withdrawal map (`RewardAccountComparer`: network, script-before-key, then hash).

- **1 withdrawal:** insertion index == sorted index → worked by coincidence.
- **2+ withdrawals:** pointers cross → the wrong redeemer is fed to each script.

Observed as a CEK eval failure (`unListData: expected list data, got PlutusDataConstr`) on a tx with two script withdrawals, where the first-sorting script was handed the second script's redeemer.

**Fix:** `BuildRedeemers` resolves each withdrawal's reward account via the threaded `parties` map, ranks them with `RewardAccountComparer.Instance`, and emits the sorted index instead of the insertion index.

### 2. Inline witness scripts for template withdrawals

Adds `WithdrawalOptions<T>.Script`. When set, `ProcessWithdrawals` embeds the script in the witness set via `AddPlutusScript` instead of requiring a reference input. Needed when a reference input would perturb ordering that a co-spent script depends on — e.g. SundaeSwap reads its settings as the first reference input, which an oracle reference input would displace.

## Testing

- `dotnet build -c Release` — **0 warnings** (`TreatWarningsAsErrors=true`).
- `dotnet test -c Release --filter "Category!=Integration"` — **all pass** (1303 tests, incl. `Chrysalis.Tx.Test`).
- Proven end-to-end on Cardano **preprod**: a wizard + Butane-oracle two-withdrawal fill validates (`valid_contract=true`), and a live-oracle transform → SundaeSwap scoop (inline oracle witness, settings head preserved) validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
